### PR TITLE
edit、update、destroyロジック実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
+  gem 'pry-byebug'
+
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
 
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'pry-remote'
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   gem 'pry-byebug'
+  gem 'pry-rails'
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
     pry-byebug (3.11.0)
       byebug (~> 12.0)
       pry (>= 0.13, < 0.16)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.2.6)
       date
       stringio
@@ -406,6 +408,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   pg (~> 1.1)
   pry-byebug
+  pry-rails
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     brakeman (7.0.2)
       racc
     builder (3.3.0)
+    byebug (12.0.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -94,6 +95,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -153,6 +155,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.3)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -219,6 +222,12 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.4.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
     psych (5.2.6)
       date
       stringio
@@ -396,6 +405,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)
+  pry-byebug
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,9 @@ GEM
       pry (>= 0.13, < 0.16)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     psych (5.2.6)
       date
       stringio
@@ -330,6 +333,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    slop (3.6.0)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -409,6 +413,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   pry-rails
+  pry-remote
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -5,23 +5,29 @@ class StocksController < ApplicationController
 
     @stocks = current_user.stocks
               .joins("LEFT JOIN (#{latest_histories.to_sql}) AS latest_histories ON latest_histories.stock_id = stocks.id")
-              .select("stocks.*, latest_histories.recording_date AS latest_recording_date, latest_histories.quantity AS latest_quantity")
+              .select("stocks.*, latest_histories.recording_date AS latest_recording_date, latest_histories.exist_quantity AS latest_exist_quantity, latest_histories.num_quantity AS latest_num_quantity")
               .order(:model ,:name)
     @locations = current_user.locations.order(:name)
   end
 
   def new
     @stock = Stock.new
-    @location = Location.find_by(name: params[:location])
+    @location = Location.find(params[:location])
     @stock.histories.build
   end
 
   def create
     @stock = current_user.stocks.build(stock_params)
+    @location = @stock.location
+    history, quantity_type = find_and_create_new_history(@stock)
+    histories_substitute(history, quantity_type)
+
+    p "history: ex:#{history.exist_quantity} num:#{history.num_quantity} #{history.status} #{history.recording_date}"
+
     if @stock.save
       redirect_to stocks_path, success: t("defaults.flash_message.created", item: t("defaults.models.stock"))
     else
-      @location = Location.find(params[:stock][:location_id])
+      p @stocks.errors.full_messages
       flash.now[:error] = t("defaults.flash_message.not_created", item: t("defaults.models.stock"))
       render :new, status: :unprocessable_entity
     end
@@ -31,10 +37,17 @@ class StocksController < ApplicationController
     @stock = current_user.stocks.find(params[:id])
     @location = @stock.location
     @locations = current_user.locations.order(:name)
+    @histories = @stock.histories.where.not(id: nil).order(id: :desc).limit(10)
+    find_and_create_new_history(@stock, permit_action: true)
   end
-
+  
   def update
     @stock = current_user.stocks.find(params[:id])
+    @location = @stock.location
+    @histories = @stock.histories.where.not(id: nil).order(id: :desc).limit(10)
+    history, quantity_type, old_quantity = find_and_create_new_history(@stock)
+    histories_substitute(history, quantity_type, old_quantity)
+    
     if @stock.update(stock_params)
       redirect_to stocks_path, success: t("defaults.flash_message.updated", item: t("defaults.models.stock"))
     else
@@ -52,6 +65,51 @@ class StocksController < ApplicationController
   private
 
   def stock_params
-    params.require(:stock).permit(:location_id, :name, :model, histories_attributes: [:id, :quantity, :status, :recording_date])
+    params.require(:stock).permit(:location_id, :name, :model, histories_attributes: [:exist_quantity, :num_quantity])
+  end
+
+  # 未保存状態の履歴を持っているか確認して取得
+  # TODO: edit or updateのときはbuildに最新のquantityを渡してあげないとストック数の表示が初期化される
+  def find_and_create_new_history(stock, permit_action: false)
+    latest_history = stock.histories.order(id: :desc).first
+    quantity_type = stock.existence? ? "exist_quantity" : "num_quantity"
+
+    old_quantity = nil
+
+    if stock.histories.none?(&:new_record?)
+      old_quantity = latest_history.send(quantity_type) if permit_action && latest_history
+      stock.histories.build(quantity_type => old_quantity)
+    else
+      history = stock.histories.find(&:new_record?)
+      if permit_action && latest_history
+        old_quantity = latest_history.send(quantity_type)
+        history.send("#{quantity_type}=", old_quantity) if history.send(quantity_type).nil?
+      end
+    end
+
+    history ||= stock.histories.find(&:new_record?)
+    return history, quantity_type, old_quantity
+  end
+
+  # ユーザーからの入力が必要ないhistoryのカラムを補完するメソッド
+  # FIXME: quantityを0で登録してもpurchaseになってしまう
+  def histories_substitute(history, quantity_type, old_quantity = nil)
+    new_quantity = history.send(quantity_type).to_i
+    model_change = history.stock.model.to_s != params[:stock][:model]
+
+    if action_name == "update" && !model_change
+      difference = old_quantity - new_quantity
+      case
+      when difference > 0
+        history.status ||= :purchase
+      when difference == 0
+        history.status ||= :purchase # 本来は履歴更新をするか確認する
+      when difference < 0
+        history.status ||= :consumption
+      end
+    else # create 又は updateだけどストック型を変更した場合
+      history.status ||= new_quantity == 0 ? :consumption : :purchase
+    end
+    history.recording_date ||= Date.today
   end
 end

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -1,7 +1,7 @@
 class StocksController < ApplicationController
   def index
     # 最新履歴を取得するためのサブクエリ用変数
-    latest_histories = History.select("DISTINCT ON (stock_id) *").order("stock_id, recording_date DESC")
+    latest_histories = History.select("DISTINCT ON (stock_id) *").order("stock_id, id DESC, recording_date DESC")
 
     @stocks = current_user.stocks
               .joins("LEFT JOIN (#{latest_histories.to_sql}) AS latest_histories ON latest_histories.stock_id = stocks.id")
@@ -13,21 +13,19 @@ class StocksController < ApplicationController
   def new
     @stock = Stock.new
     @location = Location.find(params[:location])
-    @stock.histories.build
+    @stock.histories.build(exist_quantity: 1)
   end
 
+  # DONE: histories.statusは一覧にないというエラーが発生 <= historyのvalidatesを無効にした
   def create
     @stock = current_user.stocks.build(stock_params)
     @location = @stock.location
-    history, quantity_type = find_and_create_new_history(@stock)
-    histories_substitute(history, quantity_type)
-
-    p "history: ex:#{history.exist_quantity} num:#{history.num_quantity} #{history.status} #{history.recording_date}"
 
     if @stock.save
       redirect_to stocks_path, success: t("defaults.flash_message.created", item: t("defaults.models.stock"))
     else
-      p @stocks.errors.full_messages
+      # NOTE:以下１行最終的に削除
+      p @stock.errors.full_messages if !@stock.errors.nil?
       flash.now[:error] = t("defaults.flash_message.not_created", item: t("defaults.models.stock"))
       render :new, status: :unprocessable_entity
     end
@@ -38,19 +36,19 @@ class StocksController < ApplicationController
     @location = @stock.location
     @locations = current_user.locations.order(:name)
     @histories = @stock.histories.where.not(id: nil).order(id: :desc).limit(10)
-    find_and_create_new_history(@stock, permit_action: true)
+    build_latest_history(@stock) if @stock.histories.none?(&:new_record?)
+    p build_latest_history(@stock)
   end
   
   def update
     @stock = current_user.stocks.find(params[:id])
-    @location = @stock.location
-    @histories = @stock.histories.where.not(id: nil).order(id: :desc).limit(10)
-    history, quantity_type, old_quantity = find_and_create_new_history(@stock)
-    histories_substitute(history, quantity_type, old_quantity)
-    
+
     if @stock.update(stock_params)
       redirect_to stocks_path, success: t("defaults.flash_message.updated", item: t("defaults.models.stock"))
     else
+      p @stock.errors.full_messages if !@stock.errors.nil?
+      @location = @stock.location
+      @histories = @stock.histories.where.not(id: nil).order(id: :desc).limit(10)
       flash.now[:error] = t("defaults.flash_message.not_updated", item: t("defaults.models.stock"))
       render :edit, status: :unprocessable_entity
     end
@@ -68,48 +66,18 @@ class StocksController < ApplicationController
     params.require(:stock).permit(:location_id, :name, :model, histories_attributes: [:exist_quantity, :num_quantity])
   end
 
-  # 未保存状態の履歴を持っているか確認して取得
-  # TODO: edit or updateのときはbuildに最新のquantityを渡してあげないとストック数の表示が初期化される
-  def find_and_create_new_history(stock, permit_action: false)
+  # editアクション時に直近の履歴から数量を取得したhistoryインスタンスを作成するメソッド
+  # TODO: 直近の履歴の数量を入れてビルドする
+  def build_latest_history(stock)
     latest_history = stock.histories.order(id: :desc).first
-    quantity_type = stock.existence? ? "exist_quantity" : "num_quantity"
+    quantity_type = stock.existence? ? :exist_quantity : :num_quantity
+    old_quantity = latest_history.send(quantity_type).to_i
 
-    old_quantity = nil
-
-    if stock.histories.none?(&:new_record?)
-      old_quantity = latest_history.send(quantity_type) if permit_action && latest_history
-      stock.histories.build(quantity_type => old_quantity)
-    else
-      history = stock.histories.find(&:new_record?)
-      if permit_action && latest_history
-        old_quantity = latest_history.send(quantity_type)
-        history.send("#{quantity_type}=", old_quantity) if history.send(quantity_type).nil?
-      end
+    if quantity_type == :exist_quantity
+      history = stock.histories.build(quantity_type => old_quantity)
+    elsif quantity_type == :num_quantity
+      history = stock.histories.build(exist_quantity: 1, quantity_type => old_quantity)
     end
-
-    history ||= stock.histories.find(&:new_record?)
-    return history, quantity_type, old_quantity
-  end
-
-  # ユーザーからの入力が必要ないhistoryのカラムを補完するメソッド
-  # FIXME: quantityを0で登録してもpurchaseになってしまう
-  def histories_substitute(history, quantity_type, old_quantity = nil)
-    new_quantity = history.send(quantity_type).to_i
-    model_change = history.stock.model.to_s != params[:stock][:model]
-
-    if action_name == "update" && !model_change
-      difference = old_quantity - new_quantity
-      case
-      when difference > 0
-        history.status ||= :purchase
-      when difference == 0
-        history.status ||= :purchase # 本来は履歴更新をするか確認する
-      when difference < 0
-        history.status ||= :consumption
-      end
-    else # create 又は updateだけどストック型を変更した場合
-      history.status ||= new_quantity == 0 ? :consumption : :purchase
-    end
-    history.recording_date ||= Date.today
+    history
   end
 end

--- a/app/helpers/stocks_helper.rb
+++ b/app/helpers/stocks_helper.rb
@@ -1,0 +1,2 @@
+module StocksHelper
+end

--- a/app/javascript/controllers/quantity_visibility_controller.js
+++ b/app/javascript/controllers/quantity_visibility_controller.js
@@ -15,24 +15,19 @@ export default class extends Controller {
   ];
 
   connect() {
-    this.changeModel();
+    this.changeModel(); // ラジオボタンによる表示制御
+    this.setInitialIconState(); // ← 追加：exist_quantityの初期値に応じたアイコン表示
   }
 
-  changeModel(event) {
+  changeModel() {
     const existenceSelected = this.existenceRadioTarget.checked;
 
     if (existenceSelected) {
-      // チェックボックス型が選択されているときは残数型のフィールドを非表示かつ不活性化
       this.existenceFieldTarget.classList.remove("hidden");
       this.numberFieldTarget.classList.add("hidden");
-      // this.existenceQuantityTarget.disabled = false;
-      // this.numberQuantityTarget.disabled = true;
     } else {
-      // 残数型が選択されているときはチェックボックス型のフィールドを非表示かつ不活性化
       this.existenceFieldTarget.classList.add("hidden");
       this.numberFieldTarget.classList.remove("hidden");
-      // this.existenceQuantityTarget.disabled = true;
-      // this.numberQuantityTarget.disabled = false;
     }
   }
 
@@ -41,17 +36,30 @@ export default class extends Controller {
     const explanation = this.iconExplanationTarget;
 
     if (quantity.value === "1") {
-      // チェック外す => アイコンをunchecked、在庫数quantityを0に変更
       this.checkedIconTarget.classList.add("hidden");
       this.notCheckedIconTarget.classList.remove("hidden");
       explanation.textContent = "ストックなし";
       quantity.value = 0;
     } else {
-      // チェック入れる => アイコンをchecked、在庫数quantityを1に変更
       this.notCheckedIconTarget.classList.add("hidden");
       this.checkedIconTarget.classList.remove("hidden");
       explanation.textContent = "ストックあり";
       quantity.value = 1;
+    }
+  }
+
+  setInitialIconState() {
+    const quantity = this.existenceQuantityTarget;
+    const explanation = this.iconExplanationTarget;
+
+    if (quantity.value === "1") {
+      this.checkedIconTarget.classList.remove("hidden");
+      this.notCheckedIconTarget.classList.add("hidden");
+      explanation.textContent = "ストックあり";
+    } else {
+      this.checkedIconTarget.classList.add("hidden");
+      this.notCheckedIconTarget.classList.remove("hidden");
+      explanation.textContent = "ストックなし";
     }
   }
 }

--- a/app/javascript/controllers/quantity_visibility_controller.js
+++ b/app/javascript/controllers/quantity_visibility_controller.js
@@ -3,14 +3,15 @@ import { Controller } from "@hotwired/stimulus";
 // Connects to data-controller="quantity-visibility"
 export default class extends Controller {
   static targets = [
-    "quantityExistField",
-    "quantityNumField",
+    "existenceField",
+    "numberField",
     "existenceRadio",
     "numberRadio",
+    "existenceQuantity",
+    "numberQuantity",
     "checkedIcon",
     "notCheckedIcon",
     "iconExplanation",
-    "hiddenQuantity",
   ];
 
   connect() {
@@ -22,25 +23,21 @@ export default class extends Controller {
 
     if (existenceSelected) {
       // チェックボックス型が選択されているときは残数型のフィールドを非表示かつ不活性化
-      this.quantityExistFieldTarget.classList.remove("hidden");
-      this.quantityNumFieldTarget.classList.add("hidden");
-      this.hiddenQuantityTarget.disabled = false;
-      const numField = this.quantityNumFieldTarget.querySelector("input");
-      if (numField) numField.disabled = true;
+      this.existenceFieldTarget.classList.remove("hidden");
+      this.numberFieldTarget.classList.add("hidden");
+      // this.existenceQuantityTarget.disabled = false;
+      // this.numberQuantityTarget.disabled = true;
     } else {
       // 残数型が選択されているときはチェックボックス型のフィールドを非表示かつ不活性化
-      this.quantityExistFieldTarget.classList.add("hidden");
-      this.quantityNumFieldTarget.classList.remove("hidden");
-      this.hiddenQuantityTarget.disabled = true;
-      const numField = this.quantityNumFieldTarget.querySelector("input");
-      if (numField) numField.disabled = false;
+      this.existenceFieldTarget.classList.add("hidden");
+      this.numberFieldTarget.classList.remove("hidden");
+      // this.existenceQuantityTarget.disabled = true;
+      // this.numberQuantityTarget.disabled = false;
     }
   }
 
   toggleIcon() {
-    // const checked = this.checkedIconTarget;
-    // const not_checked = this.notCheckedIconTarget;
-    const quantity = this.hiddenQuantityTarget;
+    const quantity = this.existenceQuantityTarget;
     const explanation = this.iconExplanationTarget;
 
     if (quantity.value === "1") {

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,21 +1,63 @@
 class History < ApplicationRecord
-  validates :exist_quantity, inclusion: { in: [0, 1] }
-  validates :num_quantity, numericality: { greater_than_or_equal_to: 0, less_than: 100 }
-  validates :status, presence:true, length: { maximum: 255 }
-  validates :recording_date, presence: true
-  validate :essential_quantity
-  enum status: { purchase: 0, consumption: 1 }
+  validates :exist_quantity, inclusion: { in: [0, 1] }, if: -> { stock.existence? }
+  validates :num_quantity, numericality: { greater_than_or_equal_to: 0, less_than: 100 }, if: -> { stock.number? }
+  # validates :status, inclusion: { in: [0, 1] }
+  before_validation :set_status_and_date
+  before_validation :nillify_unused_quantity
+
+  enum :status, { purchase: 0, consumption: 1 }
 
   belongs_to :stock
 
+  def quantity
+    stock.existence? ? exist_quantity.to_i : num_quantity.to_i
+  end
+
   private
 
-  # ストック型と一致する数量が入力されているか検査
-  def essential_quantity
-    if stock.existence?
-      errors.add(:exist_quantity, "が入力されていません") if exist_quantity.nil?
-    elsif stock.number?
-      errors.add(:num_quantity, "が入力されていません") if num_quantity.nil?
+  # フォームから受け取らないカラムを保存前に設定
+  def set_status_and_date
+    self.recording_date ||= Date.today
+    return if status.in?([0, 1])
+
+    if stock.histories.size == 1
+      # create時のstatus設定
+      self.status = quantity == 0 ? :consumption : :purchase
+    else
+      # update時のstatus設定
+      update_status_based_on_previous_history
+    end
+  end
+
+  def update_status_based_on_previous_history
+    return unless stock
+
+    # stock型の変更有無又は保存済の履歴の有無によって分岐
+    update_stock_model = stock.changes.has_key?(:model)
+    previous_history = stock.histories.where.not(id: id).order(id: :desc).first
+    return self.status = quantity == 0 ? :consumption : :purchase if previous_history.blank? || update_stock_model
+
+    old_quantity = stock.existence? ? previous_history.exist_quantity.to_i : previous_history.num_quantity.to_i
+    diff = old_quantity - quantity
+
+    self.status =
+      case diff <=> 0
+      when 1  then :consumption
+      when -1 then :purchase
+      # TODO: 数量を変更しなかったときは履歴のみ更新するロジックを作る
+      when 0 then :purchase
+      end
+  end
+
+  # 使用しない型のquantityをnilにしてから保存
+  def nillify_unused_quantity
+    return unless stock
+
+    case stock.model
+    when "existence"
+      self.num_quantity = nil
+    when "number"
+      self.exist_quantity = nil
     end
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,9 +1,21 @@
 class History < ApplicationRecord
-  validates :quantity, presence: true, numericality: { greater_than_or_equal_to: 0, less_than: 100 }
+  validates :exist_quantity, inclusion: { in: [0, 1] }
+  validates :num_quantity, numericality: { greater_than_or_equal_to: 0, less_than: 100 }
   validates :status, presence:true, length: { maximum: 255 }
   validates :recording_date, presence: true
-
+  validate :essential_quantity
   enum status: { purchase: 0, consumption: 1 }
 
   belongs_to :stock
+
+  private
+
+  # ストック型と一致する数量が入力されているか検査
+  def essential_quantity
+    if stock.existence?
+      errors.add(:exist_quantity, "が入力されていません") if exist_quantity.nil?
+    elsif stock.number?
+      errors.add(:num_quantity, "が入力されていません") if num_quantity.nil?
+    end
+  end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,7 +1,6 @@
 class History < ApplicationRecord
   validates :exist_quantity, inclusion: { in: [0, 1] }, if: -> { stock.existence? }
   validates :num_quantity, numericality: { greater_than_or_equal_to: 0, less_than: 100 }, if: -> { stock.number? }
-  # validates :status, inclusion: { in: [0, 1] }
   before_validation :set_status_and_date
   before_validation :nillify_unused_quantity
 

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -2,7 +2,7 @@ class Stock < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :model, presence: true, length: { maximum: 255 }
 
-  enum model: { existence: 0, number: 1 }
+  enum :model, { existence: 0, number: 1 }
 
   belongs_to :user
   belongs_to :location

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -8,7 +8,7 @@ class Stock < ApplicationRecord
   belongs_to :location
   has_many :histories, dependent: :destroy
 
-  accepts_nested_attributes_for :histories, allow_destroy: true
+  accepts_nested_attributes_for :histories
 
   # index画面で〇日前と表示するためのメソッド
   def number_of_days_elapsed

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -2,13 +2,13 @@
   <%
     case type.to_s
     when "success"
-      color = "bg-green-100 text-green-800 border-green-300"
+      color = "bg-green-100 text-green-800 border-green-500"
     when "error", "warning"
-      color = "bg-red-100 text-red-800 border-red-300"
+      color = "bg-red-100 text-red-800 border-red-500"
     when "info"
-      color = "bg-blue-100 text-blue-800 border-blue-300"
+      color = "bg-blue-100 text-blue-800 border-blue-500"
     else
-      color = "bg-gray-100 text-gray-800 border-gray-300"
+      color = "bg-gray-100 text-gray-800 border-gray-500"
     end
   %>
   <div class="animate-fadeinout container mx-auto flex justify-end absolute top-9 right-0 z-5">

--- a/app/views/stocks/_form.html.erb
+++ b/app/views/stocks/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: stock do |f| %>
+  <%# TODO: アクションに応じた保管場所の変更可否 %>
   <div class="text-2xl font-bold text-f-head mt-8">ストックの保管場所</div>
   <div class="text-xl mb-6"><%= location.name %></div>
   <%= f.hidden_field :location_id, value: location.id %>
@@ -17,21 +18,21 @@
         id: "model_existence",
         class: "accent-dull-green" %>
       <p>チェックボックス</p>
-      <p>チェックでストックを管理します</p>
+      <p>チェックマークでストック状態を管理します</p>
       <%= f.radio_button :model, :number,
         data: { action: "quantity-visibility#changeModel", quantity_visibility_target: "numberRadio" },
         id: "model_number",
         class: "accent-dull-green" %>
       <p>残数表示</p>
-      <p>残数でストックを管理します</p>
+      <p>残数でストック数を管理します</p>
     </div>
 
-    <%= f.fields_for :histories do |h| %>
+    <%# FIXME: createもupdateもエラーになってしまう %>
+    <%= f.fields_for :histories, stock.histories.select(&:new_record?) do |h| %>
       <div class="flex flex-col mb-6">
-        <%= h.label :quantity, class: "text-2xl font-bold text-f-head" %>
-      <%# DONE: JSを活用してradioの選択で表示される状態を変更、Exist型のアイコンでのquantityの制御 %>
         <!-- ラジオで選択されている型によって表示を切り替え -->
-        <div class="" data-quantity-visibility-target="quantityExistField">
+        <%= h.label :quantity, class: "text-2xl font-bold text-f-head" %>
+        <div class="" data-quantity-visibility-target="existenceField">
           <div class="flex items-center space-x-6">
 
             <!-- チェックありアイコン -->
@@ -43,33 +44,37 @@
               </svg>
             </div>
             <!-- チェックなしアイコン -->
-            <div data-action='click->quantity-visibility#toggleIcon' class="hidden" data-quantity-visibility-target="notCheckedIcon">
-              <svg class="h-12 w-12 text-f-body cursor-pointer" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <div class="hidden" data-quantity-visibility-target="notCheckedIcon">
+              <svg data-action='click->quantity-visibility#toggleIcon' class="h-12 w-12 text-f-body cursor-pointer" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z"/>
                 <rect x="4" y="4" width="16" height="16" rx="2" />
               </svg>
             </div>
             <p data-quantity-visibility-target="iconExplanation", class="text-xl">ストックあり</p>
           </div>
-          <%= h.hidden_field :quantity, value: 1, data: { quantity_visibility_target: "hiddenQuantity" } %>
-        </div>
-
-        <div class="hidden" data-quantity-visibility-target="quantityNumField">
-          <%= h.number_field :quantity, in: 0..100, class: "bg-white border-black border rounded p-2 h-12 w-16" %>
+          <%= h.hidden_field :exist_quantity, value: 1, data: { quantity_visibility_target: "existenceQuantity" } %>
+          </div>
+          
+          <div class="hidden" data-quantity-visibility-target="numberField">
+          <%= h.number_field :num_quantity, value: nil, in: 0..100, data: { quantity_visibility_target: "numberQuantity" }, class: "bg-white border-black border rounded p-2 h-12 w-16" %>
         </div>
       </div>
-
-    <%# TODO: editアクションのときは更新前のstockの値と比較して決定するロジックをelse句で実装 %>
-      <% if stock.name.nil? %>
-      <%= h.hidden_field :status, value: :purchase %>
-      <% end %>
-      
-      <%= h.hidden_field :recording_date, value: Date.today %>
     <% end %>
   </div>
 
-  <div class="flex justify-between items-center">
+  <div class="flex justify-between items-center mb-6">
     <%= f.submit "保存", class: "text-xl text-f-body bg-dull-red rounded p-4 " %>
     <%= link_to "ストック一覧に戻る", stocks_path, class: "hover:text-dull-green hover:border-b-2 border-dull-green" %>
   </div>
+  
+  <%# TODO: editのみ直近の履歴10件を表示 <= 簡易的に実装済 %>
+  <% if action_name == "edit" || action_name == "update" %>
+    <div class="text-2xl font-bold text-f-head">過去の購入履歴（直近１０件）</div>
+    <% histories.each do |history| %>
+      <div class="flex justify-start items-center space-x-4 mb-2">
+        <%= history.recording_date %>
+        <%= history.status %>
+      </div>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/stocks/_form.html.erb
+++ b/app/views/stocks/_form.html.erb
@@ -6,58 +6,56 @@
 
   <div class="flex flex-col mb-6">
     <%= f.label :name, class: "text-2xl font-bold text-f-head" %>
-    <%= f.text_field :name, placeholder: "入力してください", size: 40, class: "bg-white border-black border rounded p-2" %>
+    <%= f.text_field :name, placeholder: "入力してください", class: "bg-white border-black border rounded p-2 w-1/2" %>
   </div>
 
   <!-- stimulusを活用した非同期処理 -->
+  <%# FIXME:labelとformの使い方がよくないらしい %>
   <div data-controller="quantity-visibility">
     <%= f.label :model, class: "text-2xl font-bold text-f-head" %>
     <div class="grid grid-cols-3 auto-cols-min gap-2 mb-6">
       <%= f.radio_button :model, :existence, checked: true,
         data: { action: "quantity-visibility#changeModel", quantity_visibility_target: "existenceRadio" },
-        id: "model_existence",
         class: "accent-dull-green" %>
       <p>チェックボックス</p>
       <p>チェックマークでストック状態を管理します</p>
       <%= f.radio_button :model, :number,
         data: { action: "quantity-visibility#changeModel", quantity_visibility_target: "numberRadio" },
-        id: "model_number",
         class: "accent-dull-green" %>
       <p>残数表示</p>
       <p>残数でストック数を管理します</p>
     </div>
 
-    <%# FIXME: createもupdateもエラーになってしまう %>
-    <%= f.fields_for :histories, stock.histories.select(&:new_record?) do |h| %>
-      <div class="flex flex-col mb-6">
-        <!-- ラジオで選択されている型によって表示を切り替え -->
-        <%= h.label :quantity, class: "text-2xl font-bold text-f-head" %>
-        <div class="" data-quantity-visibility-target="existenceField">
-          <div class="flex items-center space-x-6">
+    <%# DONE: create, update の成功時失敗時ともに正常動作確認 %>
+    <%= f.fields_for :histories, stock.histories.select(&:new_record?).first do |h| %>
+      <!-- ラジオで選択されている型によって表示を切り替え -->
+      <div class="mb-6" data-quantity-visibility-target="existenceField">
+        <%= h.label :exist_quantity, class: "text-2xl font-bold text-f-head" %>
+        <div class="flex items-center space-x-6">
 
-            <!-- チェックありアイコン -->
-            <div class="" data-quantity-visibility-target="checkedIcon">
-              <svg data-action='click->quantity-visibility#toggleIcon' class="h-12 w-12 text-dull-green cursor-pointer" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                <path stroke="none" d="M0 0h24v24H0z"/>
-                <polyline points="9 11 12 14 20 6" />
-                <path d="M20 12v6a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h9" />
-              </svg>
-            </div>
-            <!-- チェックなしアイコン -->
-            <div class="hidden" data-quantity-visibility-target="notCheckedIcon">
-              <svg data-action='click->quantity-visibility#toggleIcon' class="h-12 w-12 text-f-body cursor-pointer" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                <path stroke="none" d="M0 0h24v24H0z"/>
-                <rect x="4" y="4" width="16" height="16" rx="2" />
-              </svg>
-            </div>
-            <p data-quantity-visibility-target="iconExplanation", class="text-xl">ストックあり</p>
+          <!-- チェックありアイコン -->
+          <div class="" data-quantity-visibility-target="checkedIcon">
+            <svg data-action='click->quantity-visibility#toggleIcon' class="h-12 w-12 text-dull-green cursor-pointer" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path stroke="none" d="M0 0h24v24H0z"/>
+              <polyline points="9 11 12 14 20 6" />
+              <path d="M20 12v6a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h9" />
+            </svg>
           </div>
-          <%= h.hidden_field :exist_quantity, value: 1, data: { quantity_visibility_target: "existenceQuantity" } %>
+          <!-- チェックなしアイコン -->
+          <div class="hidden" data-quantity-visibility-target="notCheckedIcon">
+            <svg data-action='click->quantity-visibility#toggleIcon' class="h-12 w-12 text-f-body cursor-pointer" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path stroke="none" d="M0 0h24v24H0z"/>
+              <rect x="4" y="4" width="16" height="16" rx="2" />
+            </svg>
           </div>
-          
-          <div class="hidden" data-quantity-visibility-target="numberField">
-          <%= h.number_field :num_quantity, value: nil, in: 0..100, data: { quantity_visibility_target: "numberQuantity" }, class: "bg-white border-black border rounded p-2 h-12 w-16" %>
+          <p data-quantity-visibility-target="iconExplanation", class="text-xl">ストックあり</p>
         </div>
+        <%= h.hidden_field :exist_quantity, data: { quantity_visibility_target: "existenceQuantity" } %>
+      </div>
+
+      <div class="hidden flex flex-col mb-6" data-quantity-visibility-target="numberField">
+        <%= h.label :num_quantity, class: "text-2xl font-bold text-f-head" %>
+        <%= h.number_field :num_quantity, in: 0..100, data: { quantity_visibility_target: "numberQuantity" }, class: "bg-white border-black border rounded p-2 h-12 w-16" %>
       </div>
     <% end %>
   </div>
@@ -67,7 +65,7 @@
     <%= link_to "ストック一覧に戻る", stocks_path, class: "hover:text-dull-green hover:border-b-2 border-dull-green" %>
   </div>
   
-  <%# TODO: editのみ直近の履歴10件を表示 <= 簡易的に実装済 %>
+  <%# TODO: 日時の表示形式、enum_helpでステータスの日本語化 %>
   <% if action_name == "edit" || action_name == "update" %>
     <div class="text-2xl font-bold text-f-head">過去の購入履歴（直近１０件）</div>
     <% histories.each do |history| %>

--- a/app/views/stocks/_stock.html.erb
+++ b/app/views/stocks/_stock.html.erb
@@ -30,13 +30,10 @@
             </div>
             <div class="text-f-body text-right mb-4">最終購入日：<%= stock.number_of_days_elapsed %></div>
             <div class="flex justify-end items-center space-x-2">
-              <%= link_to "#" do %>
-                <div class="text-xl">履歴更新</div>
-              <% end %>
               <%= link_to edit_stock_path(stock) do %>
                 <div class="text-xl">編集</div>
               <% end %>
-              <%= link_to "#" do %>
+              <%= link_to stock_path(stock), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
                 <div class="text-xl">削除</div>
               <% end %>
             </div>

--- a/app/views/stocks/_stock.html.erb
+++ b/app/views/stocks/_stock.html.erb
@@ -10,7 +10,7 @@
           <div class="text-xl">削除</div>
         <% end %>
       </div>
-      <%= link_to new_stock_path(location: location.name), class: "pr-6" do %>
+      <%= link_to new_stock_path(location: location.id), class: "pr-6" do %>
         <div class="text-xl">追加</div>
       <% end %>
     </div>
@@ -23,9 +23,9 @@
               <p class="text-f-head text-xl font-bold"><%= stock.name %></p>
               <%# TODO: renderで有無型の場合はアイコン、残数型の場合は残数を表示する %>
               <% if stock.existence? %>
-                <div class="">アイコン</div>
+                <div class=""><%= stock.latest_exist_quantity == 0 ? "なし" : "あり" %></div>
               <% else %>
-                <div class="text-f-head text-xl font-bold"><%= "残#{ stock.latest_quantity }" %></div>
+                <div class="text-f-head text-xl font-bold"><%= "残#{ stock.latest_num_quantity }" %></div>
               <% end %>
             </div>
             <div class="text-f-body text-right mb-4">最終購入日：<%= stock.number_of_days_elapsed %></div>

--- a/app/views/stocks/edit.html.erb
+++ b/app/views/stocks/edit.html.erb
@@ -1,0 +1,3 @@
+<div class="container mx-auto absolute top-24">
+  <%= render 'form', stock: @stock, location: @location, histories: @histories %>
+</div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -17,8 +17,8 @@ ja:
         name: ストック名
         model: ストック型の選択
       history:
-        exist_quantity: チェックボックス型の数量
-        num_quantity: 残数表示型の数量
+        exist_quantity: ストックの状態
+        num_quantity: ストックの個数
         status: ストックの状態
         recording_date: 記録日
   attributes:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -17,7 +17,8 @@ ja:
         name: ストック名
         model: ストック型の選択
       history:
-        quantity: ストックの個数
+        exist_quantity: チェックボックス型の数量
+        num_quantity: 残数表示型の数量
         status: ストックの状態
         recording_date: 記録日
   attributes:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,3 +20,6 @@ ja:
       stock: ストック
       location: 保管場所
       history: 履歴
+    delete_confirm: |
+      ストックを削除します
+      ストックの購入履歴も削除されますがよろしいですか？

--- a/db/migrate/20250728050521_remove_quantity_from_histories.rb
+++ b/db/migrate/20250728050521_remove_quantity_from_histories.rb
@@ -1,0 +1,5 @@
+class RemoveQuantityFromHistories < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :histories, :quantity, :integer
+  end
+end

--- a/db/migrate/20250728050645_add_exist_quantity_from_histories.rb
+++ b/db/migrate/20250728050645_add_exist_quantity_from_histories.rb
@@ -1,0 +1,6 @@
+class AddExistQuantityFromHistories < ActiveRecord::Migration[7.2]
+  def change
+    add_column :histories, :exist_quantity, :integer
+    add_column :histories, :num_quantity, :integer
+  end
+end

--- a/db/migrate/20250729171557_change_status_to_histories.rb
+++ b/db/migrate/20250729171557_change_status_to_histories.rb
@@ -1,0 +1,5 @@
+class ChangeStatusToHistories < ActiveRecord::Migration[7.2]
+  def up
+    change_column_null :histories, :status, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_23_072404) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_28_050645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "histories", force: :cascade do |t|
-    t.integer "quantity", null: false
     t.integer "status", default: 0, null: false
     t.date "recording_date"
     t.bigint "stock_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "exist_quantity"
+    t.integer "num_quantity"
     t.index ["stock_id"], name: "index_histories_on_stock_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_28_050645) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_29_171557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "histories", force: :cascade do |t|
-    t.integer "status", default: 0, null: false
+    t.integer "status", default: 0
     t.date "recording_date"
     t.bigint "stock_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
## 実装概要

- edit機能
  - newと同じformを活用
  - 過去のストック履歴を１０件まで最下段に表示

- destroy機能
  - turbo-confirmで確認ダイアログを表示

- その他
  - 消費や購入、登録日といった履歴に関するロジックはモデルで実装し、単一の責務を担うようにした