### PR TITLE
OGP画像を取得するurlをimage_urlメソッドに修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
     <meta property="og:title" content="Attakke? | ご家庭の消耗品ストック管理アプリ"/>
     <meta property="og:description" content="Attakke?(あったっけ？)はご家庭の消耗品ストックを可視化し、買いすぎや買い忘れを防止するストック管理アプリです"/>
     <meta property="og:site_name" content="Attakke?"/>
-    <meta property="og:image" content="ogp_image.svg"/>
+    <meta property="og:image" content="<%= image_url('ogp_image.svg') %>"/>
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>


### PR DESCRIPTION
## 概要

- OGPの画像を持ってくるcontentをファイル名.拡張子から修正
```diff_ruby
- content="ogp_image.svg"
+ content="<%= image_url('ogp_image.svg') %>” 
```