### PR TITLE
OGPの参照パス修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
     <meta property="og:title" content="Attakke? | ご家庭の消耗品ストック管理アプリ"/>
     <meta property="og:description" content="Attakke?(あったっけ？)はご家庭の消耗品ストックを可視化し、買いすぎや買い忘れを防止するストック管理アプリです"/>
     <meta property="og:site_name" content="Attakke?"/>
-    <meta property="og:image" content="<%= image_url('ogp_image.png') %>"/>
+    <meta property="og:image" content="<%= "#{request.base_url}/ogp_image.png" %>"/>
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>


### PR DESCRIPTION
## 概要

- 参照パスの修正
  - 開発、本番環境問わずにpublic配下の画像を持ってこれるよう
```content="<%= "#{request.base_url}/ogp_image.png" %>"```に修正