### PR TITLE
ボタンの表示分け/レイアウト微修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,27 +1,29 @@
-<header class="fixed top-0 left-0 z-10 w-full h-72px md:h-92px shadow-sm bg-white flex-none">
+<header class="fixed top-0 left-0 z-10 w-full h-18 md:h-24 shadow-sm bg-white">
   <div class="container mx-auto px-4 py-2 md:px-6 md:py-4 w-full">
     <div class="flex items-center justify-between">
       <% if user_signed_in? %>
-        <%= link_to stocks_path, class: "shadow-sm min-h-full" do %>
-          <%= image_tag 'logo.svg', class: "h-auto md:h-15" %>
+        <%= link_to stocks_path, class: "shadow-sm rounded-full" do %>
+          <%= image_tag 'favicon.svg', class: "h-10 md:h-15" %>
         <% end %>
       <% else %>
         <%= link_to root_path, class: "shadow-sm" do %>
-          <%= image_tag 'logo.svg', class: "h-auto md:h-15" %>
+          <%= image_tag 'favicon.svg', class: "h-10 md:h-15" %>
         <% end %>
       <% end %>
 
       <div class="flex items-center space-x-4 md:space-x-6">
         <% if user_signed_in? %>
           <%= link_to "使い方(準備中)", '#', class: "text-base md:text-xl text-f-head" %>
-          <%= button_to logout_path, method: :delete, class: "flex item-center text-base md:text-xl text-white bg-dull-green rounded p-4 cursor-pointer hover:brightness-70" do %>
-            <svg class="size-6 text-white" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-              <path stroke="none" d="M0 0h24v24H0z"/><path d="M14 8v-2a2 2 0 0 0 -2 -2h-7a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h7a2 2 0 0 0 2 -2v-2" /><path d="M7 12h14l-3 -3m0 6l3 -3" />
-            </svg>
+          <%= button_to logout_path, method: :delete, class: "flex item-center text-base md:text-xl text-white bg-dull-green rounded p-3 cursor-pointer hover:brightness-70" do %>
+            <div class="flex items-center">
+              <svg class="size-6 text-white" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path stroke="none" d="M0 0h24v24H0z"/><path d="M14 8v-2a2 2 0 0 0 -2 -2h-7a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h7a2 2 0 0 0 2 -2v-2" /><path d="M7 12h14l-3 -3m0 6l3 -3" />
+              </svg>
+            </div>
             <span>ログアウト</span>
           <% end %>
         <% else %>
-          <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "flex items-center text-base md:text-xl text-white bg-dull-green rounded p-4 cursor-pointer hover:brightness-70" do %>
+          <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "flex items-center text-base md:text-xl text-white bg-dull-green rounded p-3 cursor-pointer hover:brightness-70" do %>
             <div class="flex items-center size-6 bg-white rounded-full p-[6px] mr-2 text-center">
               <svg class="size-3" version="1.1" viewBox="0 0 48 48">
                 <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>

--- a/app/views/stocks/_location.html.erb
+++ b/app/views/stocks/_location.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag location do %>
-  <div class="bg-white px-4 pb-4 mb-6 rounded">
+  <div class="bg-white pb-4 mb-6 rounded">
 
-    <div class="sticky top-31 md:top-37 bg-white border border-box border-white py-4 my-1">
+    <div class="sticky top-30 md:top-36 bg-white border border-box border-white p-4">
       <div class="flex justify-between items-center">
         <div class="flex justify-start items-center space-x-2 md:space-x-4 max-w-4/5">
           <h2 class="text-xl md:text-2xl text-f-head font-bold pl-4"><%= location.name %></h2>
@@ -28,18 +28,20 @@
       </div>
     </div>
 
-    <% if stocks&.find_by(location_id: location.id).present? %>
-      <div id="<%= location.name %>_stock_list" class="lg:grid lg:grid-cols-3 lg:gap-4">
-        <% stocks.where(location_id: location.id).each do |stock| %>
-          <%= render 'stocks/stock', stock: stock %>
+    <div class="px-4">
+      <% if stocks&.find_by(location_id: location.id).present? %>
+        <div id="<%= location.name %>_stock_list" class="lg:grid lg:grid-cols-3 lg:gap-4">
+          <% stocks.where(location_id: location.id).each do |stock| %>
+            <%= render 'stocks/stock', stock: stock %>
+          <% end %>
+        </div>
+      <% elsif action_name.in?(["in_stocks", "out_of_stocks"]) %>
+        <div class="text-lg md:text-xl text-f-body pl-6">表示するストックがありません</div>
+      <% else %>
+        <%= link_to new_stock_path(location_id: location.id), data: { turbo_frame: 'modal_frame' }, class: "pl-6" do %>
+          <span class="text-lg md:text-xl text-f-body hover:text-dull-green hover:border-b-2 border-dull-green">ストックが登録されていません</span>
         <% end %>
-      </div>
-    <% elsif action_name.in?(["in_stocks", "out_of_stocks"]) %>
-      <div class="text-lg md:text-xl text-f-body pl-6">表示するストックがありません</div>
-    <% else %>
-      <%= link_to new_stock_path(location_id: location.id), data: { turbo_frame: 'modal_frame' }, class: "pl-6" do %>
-        <span class="text-lg md:text-xl text-f-body hover:text-dull-green hover:border-b-2 border-dull-green">ストックが登録されていません</span>
       <% end %>
-    <% end %>
+    </div>
   </div>
 <% end %>

--- a/app/views/stocks/index.html.erb
+++ b/app/views/stocks/index.html.erb
@@ -8,21 +8,21 @@
       <span>保管場所</span>
     <% end %>
   </div>
-  <div class="sticky top-19 md:top-25 px-4 max-h-44px z-3">
-    <div data-controller="filter-buttons" class="flex justify-start space-x-0">
+  <div class="sticky top-18 md:top-24 px-4 py-1 bg-dull-beige z-3">
+    <div data-controller="filter-buttons" class="flex justify-start items-center space-x-0">
       <%= link_to stocks_path, data: { turbo_frame: "main_frame", action: "click->filter-buttons#activate" }, class: "basis-1/3 text-center" do %>
-        <div data-filter-buttons-target="button" class="text-base md:text-xl p-2 box-border border-2 rounded text-white border-dull-green bg-dull-green hover:brightness-70">
-          すべて
+        <div data-filter-buttons-target="button" class="text-base md:text-xl h-10 flex items-center justify-center box-border border-2 rounded text-white border-dull-green bg-dull-green hover:brightness-70">
+          <span>すべて</span>
         </div>
       <% end %>
       <%= link_to in_stocks_stocks_path, data: { turbo_frame: "main_frame", action: "click->filter-buttons#activate" }, class: "basis-1/3 text-center" do %>
-        <div data-filter-buttons-target="button" class="text-base md:text-xl p-2 box-border border-2 rounded text-f-head border-black bg-white hover:text-white hover:bg-dull-green hover:border-dull-green">
-          あり
+        <div data-filter-buttons-target="button" class="text-base md:text-xl h-10 flex items-center justify-center box-border border-2 rounded text-f-head border-black bg-white hover:text-white hover:bg-dull-green hover:border-dull-green">
+          <span>あり</span>
         </div>
       <% end %>
       <%= link_to out_of_stocks_stocks_path, data: { turbo_frame: "main_frame", action: "click->filter-buttons#activate" }, class: "basis-1/3 text-center" do %>
-        <div data-filter-buttons-target="button" class="text-base md:text-xl p-2 box-border border-2 rounded text-f-head border-black bg-white hover:text-white hover:bg-dull-green hover:border-dull-green">
-          なし
+        <div data-filter-buttons-target="button" class="text-base md:text-xl h-10 flex items-center justify-center box-border border-2 rounded text-f-head border-black bg-white hover:text-white hover:bg-dull-green hover:border-dull-green">
+          <span>なし</span>
         </div>
       <% end %>
     </div>

--- a/app/views/top_pages/top.html.erb
+++ b/app/views/top_pages/top.html.erb
@@ -27,17 +27,28 @@
   </section>
 
   <div class="w-full mb-10">
-    <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "flex items-center text-xl md:text-2xl text-white bg-dull-green rounded mx-auto px-8 py-4 cursor-pointer hover:brightness-70" do %>
-      <div class="flex items-center size-6 md:size-8 bg-white rounded-full p-[6px] md:p-2 mr-2">
-        <svg class="size-3 md:size-4" version="1.1" viewBox="0 0 48 48">
-          <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
-          <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
-          <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
-          <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
-          <path fill="none" d="M0 0h48v48H0z"></path>
-        </svg>
-      </div>
-      <span>Google でログイン</span>
+    <% if user_signed_in? %>
+      <%= button_to logout_path, method: :delete, class: "flex item-center text-xl md:text-2xl text-white bg-dull-green rounded mx-auto px-8 py-4 cursor-pointer hover:brightness-70" do %>
+        <div class="flex items-center">
+          <svg class="size-6 md:size-8 text-white" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <path stroke="none" d="M0 0h24v24H0z"/><path d="M14 8v-2a2 2 0 0 0 -2 -2h-7a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h7a2 2 0 0 0 2 -2v-2" /><path d="M7 12h14l-3 -3m0 6l3 -3" />
+          </svg>
+        </div>
+        <span>ログアウト</span>
+      <% end %>
+    <% else %>
+      <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "flex items-center text-xl md:text-2xl text-white bg-dull-green rounded mx-auto px-8 py-4 cursor-pointer hover:brightness-70" do %>
+        <div class="flex items-center size-6 md:size-8 bg-white rounded-full p-[6px] md:p-2 mr-2">
+          <svg class="size-3 md:size-4" version="1.1" viewBox="0 0 48 48">
+            <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+            <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+            <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+            <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+            <path fill="none" d="M0 0h48v48H0z"></path>
+          </svg>
+        </div>
+        <span>Google でログイン</span>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要

- トップページにログインしたまま遷移してしまった場合のログインボタンの表示修正
  - ヘッダーのログインボタンと同様に表示を修正

- レイアウト微修正
  - ヘッダー等の高さを微調整し、stickyの背景を設定することでスクロール時のちらつきをなくした