### PR TITLE
パートナー機能の実装 / config/application.rbの余分なrequireを削除

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,4 @@
 require_relative "boot"
-require 'dotenv/load'
 
 require "rails/all"
 


### PR DESCRIPTION
## 概要

- config/application.rbから```require 'dotenv/load'```を削除
余分なrequireによりデプロイエラーが起きたため削除