### PR TITLE
パートナー機能の実装 / ヘッダー通知アイコン追加

### DIFF
--- a/app/controllers/partnerships_controller.rb
+++ b/app/controllers/partnerships_controller.rb
@@ -38,12 +38,13 @@ class PartnershipsController < ApplicationController
         @partnership.update!(status: :approved, token: nil)
         # after_update コールバックで反対側も更新
       end
-      PartnershipMailer.send_gmail_to_applicant(partner: current_user.partner).deliver_later
+      PartnershipMailer.send_gmail_to_applicant(current_user.partner).deliver_later
     end
     set_stocks_and_locations
     flash.now[:success] = t("defaults.flash_message.approve")
     render turbo_stream: [
       turbo_stream.replace("main_frame", partial: "stocks/main_frame", locals: { stocks: @stocks, locations: @locations }),
+      turbo_stream.update("bell_icon", partial: "shared/bell_icon"),
       turbo_stream.update("flash", partial: "shared/flash_message")
     ]
   end
@@ -69,7 +70,10 @@ class PartnershipsController < ApplicationController
       end
     end
     flash.now[:success] = t("defaults.flash_message.reject")
-    render turbo_stream: turbo_stream.update("flash", partial: "shared/flash_message")
+    render turbo_stream: [
+      turbo_stream.update("bell_icon", partial: "shared/bell_icon"),
+      turbo_stream.update("flash", partial: "shared/flash_message")  
+    ]
   end
 
   private

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -20,9 +20,9 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="relative min-h-screen bg-dull-beige text-base text-f-body font-yusei">
+  <body class="flex flex-col min-h-screen bg-dull-beige text-base text-f-body font-yusei">
     <%= render 'shared/confirm' %>
-    <main class="container mx-auto">
+    <main class="container mx-auto grow">
       <%= yield %>
     </main>
     <%= render 'shared/footer' %>

--- a/app/views/shared/_bell_icon.html.erb
+++ b/app/views/shared/_bell_icon.html.erb
@@ -1,0 +1,7 @@
+<% if current_user.partnership&.pending? %>
+  <%= link_to new_partnerships_path, data: { turbo_frame: 'modal_frame' } do %>
+    <svg class="size-8 text-dull-red" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  <% end %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,14 +28,19 @@
 
         <!-- SP: ハンバーガーメニュー -->
         <div data-controller="mobile-menus" class="block md:hidden">
-          <button class="block md:hidden" data-action="click->mobile-menus#toggle"> 
-            <svg data-mobile-menus-target="open" class="size-8 text-f-head"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
-            </svg>
-            <svg data-mobile-menus-target="close" class="hidden size-8 text-f-head" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+          <div class="flex space-x-4">
+            <%= turbo_frame_tag 'bell_icon' do %>
+              <%= render 'shared/bell_icon' %>
+            <% end %>
+            <button class="block md:hidden" data-action="click->mobile-menus#toggle"> 
+              <svg data-mobile-menus-target="open" class="size-8 text-f-head"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+              </svg>
+              <svg data-mobile-menus-target="close" class="hidden size-8 text-f-head" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
 
           <!-- ドロワーメニュー -->
           <div data-mobile-menus-target="mobileMenus" class="hidden md:hidden absolute top-18 right-0 w-1/2 bg-white shadow-md border border-gray-700 rounded flex flex-col items-center justify-items-end divide-y-2 divide-gray-700 py-2 px-4">

--- a/app/views/stocks/_location.html.erb
+++ b/app/views/stocks/_location.html.erb
@@ -1,7 +1,8 @@
 <%= turbo_frame_tag location do %>
   <div class="bg-white pb-4 mb-6 rounded">
 
-    <div class="sticky top-32 md:top-38 bg-white border border-box border-white p-4">
+    <!-- 保管場所のヘッダー -->
+    <div class="sticky top-32 md:top-38 bg-white border border-box border-white p-4 mb-1">
       <div class="flex justify-between items-center">
         <div class="flex justify-start items-center space-x-2 md:space-x-4 max-w-4/5">
           <%= link_to edit_location_path(location), data: { turbo_frame: 'modal_frame' } do %>
@@ -17,6 +18,7 @@
       </div>
     </div>
 
+    <!-- ストックリスト -->
     <div class="px-4">
       <% if stocks&.find_by(location_id: location.id).present? %>
         <div id="<%= location.name %>_stock_list" class="lg:grid lg:grid-cols-3 lg:gap-4">

--- a/app/views/stocks/_main_frame.html.erb
+++ b/app/views/stocks/_main_frame.html.erb
@@ -5,13 +5,26 @@
         <%= render 'stocks/location', { location: location, stocks: stocks } %>
       <% end %>
     <% else %>
-      <div class="bg-white rounded my-4 p-6">
-        <%= link_to new_location_path, data: { turbo_frame: 'modal_frame' } do %>
-          <span class="text-xl font-bold text-f-body hover:text-dull-green hover:border-b-2 border-dull-green">
-            ストックの保管場所を登録しましょう<br>
-            (登録フォームを開く)
-          </span>
-        <% end %>
+      <div class="bg-white rounded my-4 p-6 text-f-head">
+        <span class="text-lg font-bold">
+          保管場所が作成されていません。<br>
+          保管場所追加またはテンプレート作成機能を使いましょう！
+        </span>
+        <div class="flex items-center space-x-4 w-full pt-4">
+          <%= link_to new_location_path, data: { turbo_frame: 'modal_frame' }, class: "basis-1/2 h-full flex flex-col text-center justify-between text-dull-green hover:text-white bg-white hover:bg-dull-green box-border border-dull-green border-2 rounded py-1" do %>
+            <svg class="size-6 w-full mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"/>
+            </svg>
+            <span class="text-sm md:text-base">保管場所追加</span>
+          <% end %>
+
+          <%= link_to templetes_path, data: { turbo_frame: 'modal_frame' }, class: "basis-1/2 h-full flex flex-col text-center justify-between text-dull-green hover:text-white bg-white hover:bg-dull-green box-border border-dull-green border-2 rounded py-1" do %>
+            <svg class="size-6 w-full mx-auto" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path stroke="none" d="M0 0h24v24H0z"/><rect x="4" y="4" width="16" height="4" rx="1" /><rect x="4" y="12" width="6" height="8" rx="1" /><line x1="14" y1="12" x2="20" y2="12" /><line x1="14" y1="16" x2="20" y2="16" /><line x1="14" y1="20" x2="20" y2="20" />
+            </svg>
+            <span class="text-sm md:text-base">テンプレート</span>
+          <% end %>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## 概要

- パートナー申請受信者のヘッダーに通知アイコンを追加
  - ヘッダーに🔔のアイコンを表示するようにし、承諾や拒否に合わせて更新されるように実装
  - アプリ内で確認する場合に画面部分更新が必要となるため、public/postcontrollerでは未実装

Closes #59  