### PR TITLE
chore: 入力フィールドの微調整

### DIFF
--- a/app/views/stocks/_form.html.erb
+++ b/app/views/stocks/_form.html.erb
@@ -68,7 +68,7 @@
       <div class="hidden flex flex-col mb-10" data-quantity-visibility-target="numberField">
         <%= h.label :num_quantity, class: "text-xl font-bold text-f-head" %>
         <div class="flex items-center space-x-6">
-          <%= h.number_field :num_quantity, in: 0..100, data: { quantity_visibility_target: "numberQuantity" }, class: "bg-white border-black border rounded p-2 h-12 w-16" %>
+          <%= h.number_field :num_quantity, in: 0..100, data: { quantity_visibility_target: "numberQuantity" }, class: "bg-white border-black border rounded p-2 mr-6 h-12 w-16" %>
           <div id="plus" class="size-10 border-3 border-dull-green rounded-full cursor-pointer flex justify-center items-center" data-action="click->quantity-visibility#incrementNumber">
             <svg class="size-8 text-dull-green" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />

--- a/app/views/templetes/_stock_fields.html.erb
+++ b/app/views/templetes/_stock_fields.html.erb
@@ -37,7 +37,7 @@
 
           <!-- 残数表示型:非表示 -->
           <div data-templete-select-target="numField" class="hidden w-full mx-auto flex items-center space-x-2">
-            <%= stock_fields.number_field :num_quantity, data: { templete_select_target: "numQuantity" }, class: "w-12 border rounded p-1 mr-2" %>
+            <%= stock_fields.number_field :num_quantity, in: 0..100, data: { templete_select_target: "numQuantity" }, class: "w-12 border rounded p-1 mr-2" %>
             <div id="plus" class="size-6 border-2 border-dull-green rounded-full cursor-pointer flex justify-center items-center" data-action="click->templete-select#incrementNumber">
               <svg class="size-4 text-dull-green" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />


### PR DESCRIPTION
## 概要
- 残数表示型のストック保存に失敗すると、入力フィールド横のボタンとの距離がなくなってしまう問題を修正
- テンプレートの残数表示型で0から100までの範囲内でないと保存できないよう修正

## 対応方法
- ストック保存画面
エラー時にfield_with_errorsでフィールドがラップされることによるマージンの消失が原因
フィールドにmr-6を設定することで対応
```diff_ruby
- <%= h.number_field :num_quantity, in: 0..100, data: { quantity_visibility_target: "numberQuantity" }, class: "bg-white border-black border rounded p-2 h-12 w-16" %>
+ <%= h.number_field :num_quantity, in: 0..100, data: { quantity_visibility_target: "numberQuantity" }, class: "bg-white border-black border rounded p-2 mr-6 h-12 w-16" %>
```

- テンプレート登録画面
フィールドに ```in: 0..100``` を追加することでブラウザ側で制御をかけました
```diff_ruby
- <%= stock_fields.number_field :num_quantity, data: { templete_select_target: "numQuantity" }, class: "w-12 border rounded p-1 mr-2" %>
+ <%= stock_fields.number_field :num_quantity, in: 0..100, data: { templete_select_target: "numQuantity" }, class: "w-12 border rounded p-1 mr-2" %>
```