### PR TITLE
fix: ci.ymlの記述を微修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager --no-exit-on-warn
+        run: bundle exec brakeman --no-pager --no-exit-on-warn
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要
brakemanを走らせるコマンドを```bin/brakeman```から```bundle exec brakeman```に修正

## 修正方針
brakemanのバージョンが最新でないというエラーが出るため、runコマンドに```--no-exit-on-warn```オプションを付与していたが、binコマンドではオプションが正しく渡らないため、bundle execに変更。