### PR TITLE
Update: ストック履歴の「テンプレート作成」を「購入」に更新

### DIFF
--- a/db/migrate/20250928135628_update_history_status_from_templete_to_purchase.rb
+++ b/db/migrate/20250928135628_update_history_status_from_templete_to_purchase.rb
@@ -1,0 +1,5 @@
+class UpdateHistoryStatusFromTempleteToPurchase < ActiveRecord::Migration[7.2]
+  def change
+    History.where(status: :templete).update_all(status: :purchase)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_31_072709) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_28_135628) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## 概要
テンプレート機能が動的に変更できるように改善したため、履歴から「テンプレート作成」が不要になった。
このため、現在登録済みのストックの履歴から「テンプレート作成」を「購入」にアップデートする。

## 処理方法
1. 新規マイグレーションを発行し、```History.where(status: :templete).update_all(status: :purchase)```で全件を更新する
2. Renderのbuild設定で差分のマイグレーションが走るため、本番環境にあるデータが更新される（現時点で100件程度）

## 参考
statusの更新に伴うコールバックは未定義のため、update_allで更新しても影響はない。