### PR TITLE
Chore: db/migrate配下をrubocopのスキャン対象外に設定

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+AllCops:
+  Exclude:
+    - 'db/migrate/**/*'
+
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`


### PR DESCRIPTION
## 概要
rubocopのlintスキャン範囲からdb/migrate配下のファイルを除きました。

## 備考
適用後のmigrateファイルを編集するには基本NGのため、db/migrateはスキャン対象外に設定した。