### PR TITLE
🔧Fix: パートナー申請周りのバグ修正

### DIFF
--- a/app/controllers/partnerships_controller.rb
+++ b/app/controllers/partnerships_controller.rb
@@ -41,6 +41,7 @@ class PartnershipsController < ApplicationController
       end
       PartnershipMailer.send_gmail_to_applicant(current_user.partner).deliver_later
     end
+    current_user.reload
     set_stocks_and_locations
     flash.now[:success] = t("defaults.flash_message.approve")
     render turbo_stream: [
@@ -70,6 +71,7 @@ class PartnershipsController < ApplicationController
         # after_destroy コールバックで反対側も削除
       end
     end
+    current_user.reload
     flash.now[:success] = t("defaults.flash_message.reject")
     render turbo_stream: [
       turbo_stream.update("bell_icon", partial: "shared/bell_icon"),

--- a/app/javascript/controllers/mobile_menus_controller.js
+++ b/app/javascript/controllers/mobile_menus_controller.js
@@ -22,6 +22,7 @@ export default class extends Controller {
 
   closeIfOutside(event) {
     if (this.element.contains(event.target)) return; // 自分の中のクリックは無視
+    console.log("mobile menu close");
     this.reset();
   }
 

--- a/app/javascript/controllers/modal_frame_controller.js
+++ b/app/javascript/controllers/modal_frame_controller.js
@@ -12,9 +12,9 @@ export default class extends Controller {
   close(event) {
     // event.detail.successは、レスポンスが成功ならtrueを返す。
     // バリデーションエラー時は、falseを返す。
-    console.log("closeアクション");
     if (event.detail.success) {
-      this.modalTarget.classList.add("hidden");
+      console.log("modal close");
+      this.hideModal();
     }
   }
 
@@ -27,9 +27,14 @@ export default class extends Controller {
   // dialog外をクリックしたときにモーダルを閉じる
   clickOutside(event) {
     if (!this.dialogTarget.contains(event.target)) {
-      console.log("clickOutsideアクション");
+      console.log("modal click outside");
       this.hideModal();
     }
+  }
+
+  hideModal() {
+    console.log("modal hide");
+    this.modalTarget.classList.add("hidden");
   }
 
   // 特定の保管場所までスクロールする
@@ -40,7 +45,7 @@ export default class extends Controller {
     setTimeout(() => {
       const target = document.getElementById(id);
       if (target) {
-        const offset = 128; // top-32 分の高さ
+        const offset = 128; // ヘッダー:72 + フィルタリングボタン: 56
         const targetPosition =
           target.getBoundingClientRect().top + window.scrollY;
         const scrollTo = targetPosition - offset;
@@ -51,10 +56,5 @@ export default class extends Controller {
         });
       }
     }, 100);
-  }
-
-  hideModal() {
-    console.log("hideアクション");
-    this.modalTarget.classList.add("hidden");
   }
 }

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -3,7 +3,6 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   </head>
   <body class="bg-dull-beige">
     <%= yield %>

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -16,7 +16,6 @@
     <%= favicon_link_tag 'favicon.svg' %>
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 

--- a/app/views/partnerships/_approved.html.erb
+++ b/app/views/partnerships/_approved.html.erb
@@ -11,6 +11,6 @@
 </div>
 
 <%#= button_to "ペアを解除する", partnerships_path,
-  data: { turbo_method: :delete, action: "click->modal_flame#hideModal" },
+  data: { turbo_method: :delete, action: "turbo:submit-end->modal-frame#hideModal" },
   class: "w-full text-lg text-f-body bg-dull-red rounded p-2 hover:brightness-70"
 %>

--- a/app/views/partnerships/_pending.html.erb
+++ b/app/views/partnerships/_pending.html.erb
@@ -17,14 +17,14 @@
   <div class="basis-1/2">
     <%= button_to "承諾する", partnerships_path,
       method: :put,
-      data: { turbo_method: :put, action: "click->modal_flame#hideModal", turbo_confirm: t('defaults.confirm.partnership.approve'), confirm_button_text: "ＯＫ" },
+      form: { data: { turbo_method: :put, action: "turbo:submit-end->modal-frame#close", turbo_confirm: t('defaults.confirm.partnership.approve'), confirm_button_text: "ＯＫ" } },
       class: "w-full text-lg text-f-body bg-dull-red rounded p-2 hover:brightness-70"
     %>
   </div>
   <div class="basis-1/2">
     <%= button_to "拒否する", reject_partnerships_path,
       method: :delete,
-      data: { turbo_method: :delete, action: "click->modal_flame#hideModal", turbo_confirm: t('defaults.confirm.partnership.reject'), confirm_button_text: "ＯＫ" },
+      form: { data: { turbo_method: :delete, action: "turbo:submit-end->modal-frame#close", turbo_confirm: t('defaults.confirm.partnership.reject'), confirm_button_text: "ＯＫ" } },
       class: "w-full text-lg text-f-body bg-gray-300 rounded p-2 hover:bg-gray-400"
     %>
   </div>

--- a/app/views/partnerships/_sended.html.erb
+++ b/app/views/partnerships/_sended.html.erb
@@ -14,6 +14,6 @@
 
 <%= button_to "申請を取り下げる", partnerships_path,
   method: :delete,
-  data: { action: "click->modal_flame#hideModal", turbo_confirm: t('defaults.confirm.partnership.withdrawal'), confirm_button_text: "ＯＫ" },
+  form: { data: { action: "turbo:submit-end->modal-frame#close", turbo_confirm: t('defaults.confirm.partnership.withdrawal'), confirm_button_text: "ＯＫ" } },
   class: "w-full text-lg text-f-body bg-dull-red rounded p-2 hover:brightness-70"
 %>

--- a/app/views/shared/_confirm.html.erb
+++ b/app/views/shared/_confirm.html.erb
@@ -1,4 +1,4 @@
-<%# 背景 %>
+<!-- 背景 -->
 <div
   data-controller="confirm"
   data-confirm-target="modal"
@@ -6,7 +6,7 @@
   class="fixed inset-0 bg-black/50 flex items-center justify-center hidden z-50"
 >
 
-  <%# 確認メッセージ %>
+  <!-- 確認メッセージ -->
   <div data-confirm-target="dialog" class="w-sm bg-white p-4 rounded shadow">
     <div class="flex justify-end item-center mb-2" data-action="click->confirm#hideModal">
       <svg class="size-6 text-gray-700" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -16,7 +16,7 @@
     </div>
     <p data-confirm-target="message" class="mb-4 text-base md:text-lg"></p>
 
-    <%# ボタン系 <= confirmボタンはデフォルトでは「削除」表示 %>
+    <!-- ボタン -->
     <div class="flex item-center space-x-4">
       <button
         type="button"
@@ -24,6 +24,7 @@
         data-action="click->confirm#confirm"
         class="basis-1/2 text-lg p-2 bg-dull-red rounded hover:brightness-70"
       >
+      <%# ここに confirm_button_text で指定したテキストが入る。デフォルトは「削除」 %>
       </button>
       <button
         type="button"

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,27 +12,13 @@
       <% end %>
 
       <% if user_signed_in? %>
-        <!-- PC: フレックスでメニュー表示 -->
-        <div class="hidden md:flex items-center space-x-6">
-          <%= link_to "使い方(準備中)", '#', class: "text-xl text-f-head" %>
-          <%= link_to "パートナー設定", new_partnerships_path, data: { turbo_frame: 'modal_frame' }, class: "text-xl text-f-head" %>
-          <%= button_to logout_path, method: :delete, class: "flex item-center text-xl text-white bg-dull-green rounded p-3 cursor-pointer hover:brightness-70" do %>
-            <div class="flex items-center">
-              <svg class="size-6 text-white" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                <path stroke="none" d="M0 0h24v24H0z"/><path d="M14 8v-2a2 2 0 0 0 -2 -2h-7a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h7a2 2 0 0 0 2 -2v-2" /><path d="M7 12h14l-3 -3m0 6l3 -3" />
-              </svg>
-            </div>
-            <span>ログアウト</span>
-          <% end %>
-        </div>
-
-        <!-- SP: ハンバーガーメニュー -->
-        <div data-controller="mobile-menus" class="block md:hidden">
+        <!-- ハンバーガーメニュー -->
+        <div data-controller="mobile-menus" class="block">
           <div class="flex space-x-4">
             <%= turbo_frame_tag 'bell_icon' do %>
               <%= render 'shared/bell_icon' %>
             <% end %>
-            <button class="block md:hidden" data-action="click->mobile-menus#toggle"> 
+            <button class="block" data-action="click->mobile-menus#toggle"> 
               <svg data-mobile-menus-target="open" class="size-8 text-f-head"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
               </svg>
@@ -43,9 +29,9 @@
           </div>
 
           <!-- ドロワーメニュー -->
-          <div data-mobile-menus-target="mobileMenus" class="hidden md:hidden absolute top-18 right-0 w-1/2 bg-white shadow-md border border-gray-700 rounded flex flex-col items-center justify-items-end divide-y-2 divide-gray-700 py-2 px-4">
+          <div data-mobile-menus-target="mobileMenus" class="hidden absolute top-18 right-0 w-1/2 bg-white shadow-md border border-gray-700 rounded flex flex-col items-center justify-items-end divide-y-2 divide-gray-700 py-2 px-4">
             <%= link_to "使い方(準備中)", '#', class: "text-base text-f-head p-3" %>
-            <%= link_to "パートナー設定", new_partnerships_path, data: { turbo_frame: 'modal_frame' }, class: "text-base text-f-head p-3" %>
+            <%= link_to "パートナー設定", new_partnerships_path, data: { turbo_frame: 'modal_frame', action: "click->mobile-menus#reset" }, class: "text-base text-f-head p-3" %>
             <%= button_to logout_path, method: :delete, class: "flex item-center text-base text-dull-green p-3 cursor-pointer hover:brightness-70" do %>
               <div class="flex items-center">
                 <svg class="size-6 text-dull-green" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## 概要
<!-- 何を実装するかを簡潔に説明 -->
パートナーシップ機能周りで以下のバグを修正。
1. 送信者、受信者ともに操作終了時のモーダルが閉じない。
2. メールが送信されていない。

## 対応詳細
1. 閉じるためのTurboアクションがbuttonタグについていたため、発火していなかった。
  button_toヘルパーに付与するオプションを変更したことにより、formタグにactionが付与され、正常に動作するようになった。
  ```diff_ruby
  - <%= button_to "拒否する", reject_partnerships_path, data: { action: "turbo:submit-end-> ... " } %>
  + <%= button_to "拒否する", reject_partnerships_path, form: { data: { action: "turbo:submit-end-> ... " } } %>
  ```
2. head内に削除したstylesheetのlink_tagが含まれていたことによりエラーが発生していた。  当該tagを削除したところ、メールが送られるようになった。

## 確認した動作
<!-- 完了とみなす条件をチェックボックスで列挙 -->
- [x] パートナー申請周りの各操作の終了時にモーダルを閉じるようにする
- [x] 申請時にメールが送られるようにする

## closeするissue
#96 パートナー申請周りのバグ修正