### PR TITLE
✨Improve: ログアウトせずにtopページへ遷移しないように制御を追加

### DIFF
--- a/app/controllers/top_pages_controller.rb
+++ b/app/controllers/top_pages_controller.rb
@@ -1,5 +1,6 @@
 class TopPagesController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :after_sign_in_path_for, if: :user_signed_in?
 
   def top
     @description = [
@@ -44,5 +45,12 @@ class TopPagesController < ApplicationController
           今買うべきか判断できます"
       }
     ]
+  end
+
+  private
+
+  def after_sign_in_path_for
+    flash[:error] = t("defaults.flash_message.logout_not_completed")
+    redirect_back fallback_location: stocks_path
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -19,6 +19,7 @@ ja:
       approve: 申請を承諾しました
       withdrawal: 申請を取り下げました
       reject: 申請を拒否しました
+      logout_not_completed: ログアウトしてください
     models:
       user: ユーザー
       stock: ストック


### PR DESCRIPTION
### 概要
ログアウトせずにtopページへ遷移できないようにtop_controllerに制御を追加

### 実装詳細
redirect_ back でstocks/indexに遷移し、フラッシュメッセージでログアウトを促すように改善。

### closeするissue
- #83