### PR TITLE
✨Feature: リアルタイム更新の実装

### DIFF
--- a/app/controllers/concerns/broadcast.rb
+++ b/app/controllers/concerns/broadcast.rb
@@ -1,0 +1,11 @@
+# ActionCableで配信するサービスクラスオブジェクト
+
+module Broadcast
+  extend ActiveSupport::Concern
+
+  private
+
+  def broadcast
+    Broadcaster.new(current_user)
+  end
+end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,47 +1,45 @@
 class LocationsController < ApplicationController
   include SetStocksAndLocations
+  include Broadcast
 
   before_action :set_stocks_and_locations, only: %i[update destroy]
   before_action :set_location, only: %i[edit update destroy]
+
 
   # 「保管場所一覧」用のアクション
   def index
     @locations = our_locations.order(:name)
   end
 
+
   def edit; end
 
   def update
     if @location.update(location_params)
+      broadcast.replace_location(@location, @stocks)
       flash.now[:success] = t("defaults.flash_message.updated", item: t("defaults.models.location"))
-      render turbo_stream: [
-        turbo_stream.replace(@location, partial: "stocks/location", locals: { location: @location, stocks: @stocks }),
-        turbo_stream.update("flash", partial: "shared/flash_message")
-      ]
+      render turbo_stream: turbo_stream.update("flash", partial: "shared/flash_message")
     else
       render :edit, status: :unprocessable_entity
     end
   end
 
+
   def destroy
     @location.destroy!
     @locations.reload
-    flash.now[:success] = t("defaults.flash_message.deleted", item: t("defaults.models.location"))
 
     # 保管場所が1つも存在しなくなった場合、ベース画面に新規作成を促すメッセージを表示する
     if our_locations.count == 0
-      render turbo_stream: [
-        turbo_stream.replace("main_frame", partial: "stocks/main_frame", locals: { stocks: @stocks, locations: @locations }),
-        turbo_stream.update("flash", partial: "shared/flash_message"),
-        turbo_stream.update("modal_frame")
-      ]
+      broadcast.replace_main_frame(@locations, @stocks)
     else
-      render turbo_stream: [
-        turbo_stream.remove("location_#{@location.id}"),
-        turbo_stream.update("flash", partial: "shared/flash_message"),
-        turbo_stream.update("modal_frame")
-      ]
+      broadcast.remove_location(@location)
     end
+    flash.now[:success] = t("defaults.flash_message.deleted", item: t("defaults.models.location"))
+    render turbo_stream: [
+      turbo_stream.update("flash", partial: "shared/flash_message"),
+      turbo_stream.update("modal_frame")
+    ]
   end
 
   # NOTE: 以下privateメソッド

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -1,8 +1,10 @@
 class StocksController < ApplicationController
   include SetStocksAndLocations
+  include Broadcast
 
   before_action :set_stocks_and_locations, only: %i[index in_stocks out_of_stocks create update destroy]
   before_action :set_stock_locations_and_last_10_histories, only: %i[edit update]
+
 
   # ログイン後のベース画面
   def index
@@ -20,6 +22,7 @@ class StocksController < ApplicationController
     render_stocks_and_locations
   end
 
+
   # ストック型のデフォルト表示がチェックボックスのため、exist_quantityに初期値を設定
   def new
     @stock = Stock.new
@@ -32,26 +35,20 @@ class StocksController < ApplicationController
     @location = @stock.location
 
     if @stock.save
-      flash.now[:success] = t("defaults.flash_message.created", item: t("defaults.models.stock"))
-
       # 保管場所にストックが存在しない場合、ストック追加を促すメッセージが表示されている
       # 当該メッセージを非表示にするために更新範囲を変更する
       if @location.stocks.count == 1
-        render turbo_stream: [
-          turbo_stream.replace(@location, partial: "location", locals: { location: @location, stocks: @stocks }),
-          turbo_stream.update("flash", partial: "shared/flash_message")
-        ]
+        broadcast.replace_location(@location, @stocks)
       else
-        render turbo_stream: [
-          turbo_stream.prepend("#{@location.name}_stock_list", partial: "stock", locals: { stock: @stocks.find(@stock.id) }),
-          turbo_stream.update("flash", partial: "shared/flash_message")
-        ]
+        broadcast.prepend_stock(@location, @stocks.find(@stock.id))
       end
-
+      flash.now[:success] = t("defaults.flash_message.created", item: t("defaults.models.stock"))
+      render turbo_stream: turbo_stream.update("flash", partial: "shared/flash_message")
     else
       render :new, status: :unprocessable_entity
     end
   end
+
 
   def edit
     build_latest_history(@stock) if @stock.histories.none?(&:new_record?)
@@ -59,48 +56,39 @@ class StocksController < ApplicationController
 
   def update
     if @stock.update(stock_params)
-      flash.now[:success] = t("defaults.flash_message.updated", item: t("defaults.models.stock"))
-
       # 保管場所が変更されているかどうかで更新範囲を変更する
       if @stock.previous_changes.has_key?(:location_id)
-        render turbo_stream: [
-          turbo_stream.replace("main_frame", partial: "main_frame", locals: { stocks: @stocks, locations: @locations }),
-          turbo_stream.update("flash", partial: "shared/flash_message")
-        ]
+        before_id, after_id = @stock.previous_changes[:location_id]
+        broadcast.replace_location(Location.find(before_id), @stocks)
+        broadcast.replace_location(Location.find(after_id), @stocks)
       else
-        render turbo_stream: [
-          turbo_stream.replace(@stock, partial: "stock", locals: { stock: @stocks.find(@stock.id) }),
-          turbo_stream.update("flash", partial: "shared/flash_message")
-        ]
+        broadcast.replace_stock(@stocks.find(@stock.id))
       end
-
+      flash.now[:success] = t("defaults.flash_message.updated", item: t("defaults.models.stock"))
+      render turbo_stream: turbo_stream.update("flash", partial: "shared/flash_message")
     else
       render :edit, status: :unprocessable_entity
     end
   end
 
+
   def destroy
     stock = our_stocks.find(params[:id])
     location = stock.location
-
     stock.destroy!
-    flash.now[:success] = t("defaults.flash_message.deleted", item: t("defaults.models.stock"))
 
     # 保管場所にストックが存在しなくなった場合、ストック追加を促すメッセージを表示する
     # 当該メッセージを表示するために更新範囲を変更する
     if location.stocks.count == 0
-      render turbo_stream: [
-        turbo_stream.replace(location, partial: "location", locals: { location: location, stocks: @stocks }),
-        turbo_stream.update("flash", partial: "shared/flash_message"),
-        turbo_stream.update("modal_frame")
-      ]
+      broadcast.replace_location(location, @stocks)
     else
-      render turbo_stream: [
-        turbo_stream.remove("stock_#{stock.id}"),
-        turbo_stream.update("flash", partial: "shared/flash_message"),
-        turbo_stream.update("modal_frame")
-      ]
+      broadcast.remove_stock(stock)
     end
+    flash.now[:success] = t("defaults.flash_message.deleted", item: t("defaults.models.stock"))
+    render turbo_stream: [
+      turbo_stream.update("flash", partial: "shared/flash_message"),
+      turbo_stream.update("modal_frame")
+    ]
   end
 
   # NOTE: 以下privateメソッド
@@ -110,14 +98,14 @@ class StocksController < ApplicationController
     params.require(:stock).permit(:location_id, :name, :model, histories_attributes: [ :exist_quantity, :num_quantity ])
   end
 
-  # edit, updateアクションで使用するデータセット
+  # edit, updateで使用するデータセット
   def set_stock_locations_and_last_10_histories
     @stock = our_stocks.find(params[:id])
     @locations = our_locations.order(:name)
     @histories = @stock.histories.where.not(id: nil).order(id: :desc).limit(10)
   end
 
-  # editで直近の履歴を反映したhistoryインスタンスを作成するメソッド
+  # editで最新履歴の数量を反映したhistoryインスタンスを作成するメソッド
   def build_latest_history(stock)
     latest_history = stock.histories.order(id: :desc).first
     quantity_type = stock.existence? ? :exist_quantity : :num_quantity

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -10,17 +10,17 @@ class Stock < ApplicationRecord
 
   accepts_nested_attributes_for :histories
 
-  # 各ストックに最新履歴を連結する
-  def self.joins_latest_history(latest_history)
-    joins("LEFT JOIN (#{latest_history.to_sql}) AS latest_history ON latest_history.stock_id = stocks.id")
-    .select("stocks.*, latest_history.recording_date AS latest_recording_date, latest_history.exist_quantity AS latest_exist_quantity, latest_history.num_quantity AS latest_num_quantity")
-  end
-
   # フィルタリングに使用するscope
   # 使用しない型の数量はnilで保存しているため、COALESCEで０に置換して判定している
   scope :order_asc_model_and_name, -> { order(:model, :name) }
   scope :in_stocks, -> { where("COALESCE(latest_history.exist_quantity, 0) > 0 OR COALESCE(latest_history.num_quantity, 0) > 0") }
   scope :out_of_stocks, -> { where("COALESCE(latest_history.exist_quantity, 0) = 0 AND COALESCE(latest_history.num_quantity, 0) = 0") }
+
+  # 各ストックに最新履歴を連結する
+  def self.joins_latest_history(latest_history)
+    joins("LEFT JOIN (#{latest_history.to_sql}) AS latest_history ON latest_history.stock_id = stocks.id")
+    .select("stocks.*, latest_history.recording_date AS latest_recording_date, latest_history.exist_quantity AS latest_exist_quantity, latest_history.num_quantity AS latest_num_quantity")
+  end
 
   # index画面で〇日前と表示するためのメソッド
   def number_of_days_elapsed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,12 @@ class User < ApplicationRecord
   has_many :stocks, dependent: :destroy
   has_many :locations, dependent: :destroy
   has_many :histories, through: :stocks, dependent: :destroy
+  
+  # ActionCable用のストリームキー
+  # nilを排除してからソートすることでパートナーシップにより紐づいている２人を表現できる
+  def partnership_stream_key
+    [id, partner&.id].compact.sort.join("_")
+  end
 
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,11 +28,11 @@ class User < ApplicationRecord
   has_many :stocks, dependent: :destroy
   has_many :locations, dependent: :destroy
   has_many :histories, through: :stocks, dependent: :destroy
-  
+
   # ActionCable用のストリームキー
   # nilを排除してからソートすることでパートナーシップにより紐づいている２人を表現できる
   def partnership_stream_key
-    [id, partner&.id].compact.sort.join("_")
+    [ id, partner&.id ].compact.sort.join("_")
   end
 
   def self.from_omniauth(auth)

--- a/app/services/broadcaster.rb
+++ b/app/services/broadcaster.rb
@@ -1,0 +1,72 @@
+class Broadcaster
+
+  def initialize(user)
+    @current_user = user
+  end
+
+  def prepend_location(location, stocks)
+    Turbo::StreamsChannel.broadcast_prepend_to(
+      stream_key,
+      target: "locations",
+      partial: "stocks/location",
+      locals: { location: location, stocks: stocks }
+    )
+  end
+
+  def replace_location(location, stocks)
+    Turbo::StreamsChannel.broadcast_replace_to(
+      stream_key,
+      target: "location_#{location.id}",
+      partial: "stocks/location",
+      locals: { location: location, stocks: stocks }
+    )
+  end
+
+  def remove_location(location)
+    Turbo::StreamsChannel.broadcast_remove_to(
+      stream_key,
+      target: "location_#{location.id}"
+    )
+  end
+
+  def prepend_stock(location, stock)
+    Turbo::StreamsChannel.broadcast_prepend_to(
+      stream_key,
+      target: "location_#{location.id}_stocks_list",
+      partial: "stocks/stock",
+      locals: { location: location, stock: stock }
+    )
+  end
+
+  def replace_stock(stock)
+    Turbo::StreamsChannel.broadcast_replace_to(
+      stream_key,
+      target: "stock_#{stock.id}",
+      partial: "stocks/stock",
+      locals: { stock: stock }
+      )
+    end
+
+  def remove_stock(stock)
+    Turbo::StreamsChannel.broadcast_remove_to(
+      stream_key,
+      target: "stock_#{stock.id}"
+      )
+  end
+
+  def replace_main_frame(locations, stocks)
+    Turbo::StreamsChannel.broadcast_replace_to(
+      stream_key,
+      target: "main_frame",
+      partial: "stocks/main_frame",
+      locals: { locations: locations, stocks: stocks }
+    )
+  end
+
+  # NOTE: 以下privateメソッド
+  private
+
+  def stream_key
+    @current_user.partnership_stream_key
+  end
+end

--- a/app/services/broadcaster.rb
+++ b/app/services/broadcaster.rb
@@ -1,5 +1,4 @@
 class Broadcaster
-
   def initialize(user)
     @current_user = user
   end

--- a/app/views/stocks/_location.html.erb
+++ b/app/views/stocks/_location.html.erb
@@ -21,7 +21,7 @@
     <!-- ストックリスト -->
     <div class="px-4">
       <% if stocks&.find_by(location_id: location.id).present? %>
-        <div id="<%= location.name %>_stock_list" class="lg:grid lg:grid-cols-3 xl:grid-cols-4 lg:gap-4">
+        <div id="location_<%= location.id %>_stocks_list" class="lg:grid lg:grid-cols-3 xl:grid-cols-4 lg:gap-4">
           <% stocks.where(location_id: location.id).each do |stock| %>
             <%= render 'stocks/stock', stock: stock %>
           <% end %>

--- a/app/views/stocks/index.html.erb
+++ b/app/views/stocks/index.html.erb
@@ -1,4 +1,7 @@
 <div id="index" class="w-full">
+  <!-- ActionCableの購買キーをセット -->
+  <%= turbo_stream_from current_user.partnership_stream_key %>
+
   <div class="sticky top-18 md:top-24 px-4 py-2 bg-dull-beige z-3">
     <div data-controller="filter-buttons" class="flex justify-start items-center space-x-0">
       <%= link_to stocks_path, data: { turbo_frame: "main_frame", action: "click->filter-buttons#activate" }, class: "basis-1/3 text-center" do %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: myapp_production
+  url: <%= ENV.fetch("REDIS_URL") %>
+  channel_prefix: attakke_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,8 +41,8 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+  config.action_cable.url = "https://attakke.onrender.com/cable"
+  config.action_cable.allowed_request_origins = [ "https://attakke.onrender.com", /https:\/\/attakke.onrender.*/ ]
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,4 +41,8 @@ Rails.application.routes.draw do
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
+
+  if Rails.env.production?
+    mount ActionCable.server => "/cable"
+  end
 end


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
ActionCableを利用してユーザーとパートナーの画面更新を同期させるように実装した。
これまでturbo_streamで即時更新していた記述を同期する処理についてはブロードキャストに変更した。

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
- パートナーが設定されているユーザーについては、２人のストック状況が共有されるため、お互いが操作した内容が即時反映されるようActionCableを用いたリアルタイム更新を実装した。
  - Userモデルにストリーム配信するためのキーを設定
  - stocks/index（ログイン後のメインページ）に配信用のキーを設定
  - 各コントローラのアクションの中で、同期するパーシャルのみブロードキャストに変更（フラッシュメッセージやモーダルなどの操作者のみ更新が走ればよいものはturboで更新）

## 参考資料
<!-- 実装にあたり参考にした資料があればURL等を貼付 -->
- 環境設定の参考記事
https://qiita.com/kurichii/items/9e506c25c472ec98b425
- 実装上で参考にした記事
https://qiita.com/yuppymam/items/de3f5311418d77f627db

## closeするissue
<!-- 実装に紐づくissueがあれば記述 -->
- close #101