### PR TITLE
🔧Fix: GitHubアクションのtestでエラーにならないようci.ymlに環境変数を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
+          REDIS_URL: redis://localhost:6379/0 # 開発環境でredisは使っていないが、cable.ymlを読み込むときにエラーにならないように設定
         run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
GitHubアクションでtest実行時に環境変数が読み込めないエラーを修正

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
```config/cable.yml```のproducution環境にのみ```REDIS_URL```の環境変数を設定した。
本番環境のコードのため、test環境には影響はないと思っていたが、testの際はファイル全体がチェックされるため、以下のエラーが発生した。
```
KeyError: key not found: "REDIS_URL" (KeyError)
```
これを回避するために、```ci.yml```にダミーの変数を渡すことにする。