### PR TITLE
✨Add: gem 'redis'導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,10 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.26.1)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -431,6 +435,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)
+  redis
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
gem 'redis' を導入

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
開発環境では```adapter: async```で動作確認していたため、導入し忘れていた。
デプロイ環境でサーバーログにエラーが出ていた。