### PR TITLE
🆙Update: アセットの参照先を指定

### DIFF
--- a/app/views/stocks/_stock.html.erb
+++ b/app/views/stocks/_stock.html.erb
@@ -3,8 +3,13 @@
   <div class="px-4 py-2 rounded border border-box mb-2 lg:mb-0 <%= set_bg_and_border_color(stock) %>">
 
     <div class="flex justify-between items-center mb-2">
-      <%= link_to edit_stock_path(stock), data: { turbo_frame: 'modal_frame' } do %>
+      <%= link_to edit_stock_path(stock), data: { turbo_frame: 'modal_frame' }, class: "flex items-center space-x-4" do %>
         <h3 class="text-f-head text-xl font-bold"><%= stock.name %></h3>
+        <% if stock.purchase_target %>
+          <svg class="size-6 text-f-head" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <path stroke="none" d="M0 0h24v24H0z"/>  <circle cx="9" cy="19" r="2" /><circle cx="17" cy="19" r="2" /><path d="M3 3h2l2 12a3 3 0 0 0 3 2h7a3 3 0 0 0 3 -2l1 -7h-15.2" />
+          </svg>
+        <% end %>
       <% end %>
       <%= render 'stocks/quantity_icon', stock: stock %>
     </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,9 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "http://assets.example.com"
+  config.action_controller.asset_host = "https://mada-attakke.com"
+  Rails.application.routes.default_url_options[:host] = "mada-attakke.com"
+  Rails.application.routes.default_url_options[:protocol] = "https"
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
@@ -41,8 +43,8 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  config.action_cable.url = "https://attakke.onrender.com/cable"
-  config.action_cable.allowed_request_origins = [ "https://attakke.onrender.com", /https:\/\/attakke.onrender.*/ ]
+  config.action_cable.url = "https://mada-attakke.com/cable"
+  config.action_cable.allowed_request_origins = [ "https://mada-attakke.com", /https:\/\/mada-attakke.*/ ]
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
@@ -78,16 +80,16 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "attakke.onrender.com", protocol: "https" }
+  config.action_mailer.default_url_options = { host: "mada-attakke.com", protocol: "https" }
   config.action_mailer.raise_delivery_errors = true
-  config.action_controller.asset_host = "attakke.onrender.com"
-  config.action_mailer.asset_host = "https://attakke.onrender.com"
+  config.action_controller.asset_host = "mada-attakke.com"
+  config.action_mailer.asset_host = "https://mada-attakke.com"
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
   address:         "smtp.gmail.com",
   port:            587,
-  domain:          "attakke.onrender.com",
+  domain:          "mada-attakke.com",
   user_name:       ENV["GMAIL_USERNAME"],
   password:        ENV["GMAIL_PASSWORD"],
   authentication:  "plain",


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
独自ドメインの設定に伴いproduction環境のアセット参照先を指定

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
アセットファイルの参照先が```.onrender.com```配下となっており、CORS（Cross-Origin Resource Sharing）エラーが発生していた。
アセットのデフォルトURLが内部的に元のドメインに設定されてしまっていることが原因のため、configにassets_hostを設定することで読み込み先のURLを指定する。

## 参考資料
<!-- 実装にあたり参考にした資料があればURL等を貼付 -->
https://railsguides.jp/v7.0/configuring.html#config-asset-host
