### PR TITLE
🔧fix: confirmモーダルのz-indexを他のindexよりも大きくなるように修正

### DIFF
--- a/app/views/shared/_confirm.html.erb
+++ b/app/views/shared/_confirm.html.erb
@@ -3,7 +3,7 @@
   data-controller="confirm"
   data-confirm-target="modal"
   data-action="click->confirm#clickOutside"
-  class="fixed inset-0 bg-black/50 flex items-center justify-center hidden z-50"
+  class="fixed inset-0 bg-black/50 flex items-center justify-center hidden z-70"
 >
 
   <!-- 確認メッセージ -->


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
confirmモーダルのz-indexを70に設定することで、必ず最前面に来るように修正

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
モーダルのz-indexが60、confirmモーダルのそれが50に設定されていたため、ストックや保管場所の削除などモーダル上の操作を確定するための確認モーダルが隠れてしまっていた。
これを確認モーダルのz-indexを70に設定することで、常に最前面に来るように修正する。