### PR TITLE
🔧fix: マイグレーションをActiveRecordベースからSQLに変更

### DIFF
--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -12,8 +12,7 @@ class Stock < ApplicationRecord
   accepts_nested_attributes_for :histories
 
   # 保管場所ごとに並び替えのposition値を管理
-  # TODO: マイグレーション適用後にコメントイン
-  # acts_as_list scope: :location
+  acts_as_list scope: :location
 
   # フィルタリングに使用するscope
   # 使用しない型の数量はnilで保存しているため、COALESCEで０に置換して判定している


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
本番環境でActiveRecordベースのマイグレーション実行時にエラーが発生したため、ロールバックでマイグレーションが未適用になった
ループ処理で数百件のレコード更新時にエラーが発生している可能性があるため、SQLベースで一括更新に変更した
また、モデルに定義したacts_as_listをマイグレーション適用時にコメントアウトし、適用後にコメントインして再適用した

## エラー原因
<!-- バグ修正の場合などは原因の分析と対処法を記述 -->
考えられる原因は以下２つ
- Neonが複数件の更新時に途中で失敗している
- Stockモデルにacts_as_listを定義していたことで存在しないpositionカラムを参照しようとしていた

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
本番環境への反映のため、確実性を重視しそれぞれを同時に対処した
- 複数件の更新ではなく、SQL文で一括登録する
- マイグレーション適用時にはacts_as_listをコメントアウトし、Railsがモデルを参照したうえでマイグレーションを実行するときはエラーになることを防ぐ

## 結果
<!-- 対応した結果どうなったのかを記述 -->
マイグレーションが適用され、Stockにpositionがデフォルトの並び順で適用された
