### PR TITLE
🔧fix: sticky周りの表示調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,9 +62,9 @@
       <%= yield %>
     </main>
 
-    <div id="footer_menu">
+    <nav id="footer_menu" class="sticky bottom-0 left-0 w-full h-14 bg-white shadow-sm z-10">
       <%= render "shared/footer_menu" %>
-    </div>
+    </nav>
     <%= render "shared/footer", cached: true %>
 
     <%= turbo_frame_tag "modal_frame" %>

--- a/app/views/shared/_footer_menu.html.erb
+++ b/app/views/shared/_footer_menu.html.erb
@@ -1,27 +1,25 @@
 <% if user_signed_in? %>
-  <nav class="sticky bottom-0 left-0 w-full h-14 bg-white shadow-sm z-10">
-    <div class="flex h-full w-full max-w-xl mx-auto items-center gap-4 px-4">
+  <div class="flex h-full w-full max-w-xl mx-auto items-center gap-4 px-4">
 
-      <% if current_list_type_value == "all" && current_sort_mode_value == "off" %>
-        <%= link_to templetes_path, data: { turbo_frame: 'modal_frame' }, class: "group flex-1 h-11 md:h-12 flex items-center justify-center gap-3 rounded-full bg-dull-green text-white font-semibold shadow-lg transition duration-200 ease-out hover:-translate-y-0.5 hover:bg-dull-red focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dull-green focus-visible:ring-offset-2 focus-visible:ring-offset-white" do %>
-          <span class="flex size-10 items-center justify-center rounded-full bg-dull-beige/30 text-white transition duration-200 ease-out group-hover:bg-dull-beige/40">
-            <svg class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"/>
-            </svg>
-          </span>
-          <span class="text-xs md:text-base tracking-wide">作成・追加</span>
-        <% end %>
-      <% end %>
-
-      <%= link_to locations_path, data: { turbo_frame: 'modal_frame' }, class: "group flex-1 h-11 md:h-12 flex items-center justify-center gap-3 rounded-full bg-dull-green text-white font-semibold shadow-lg transition duration-200 ease-out hover:-translate-y-0.5 hover:bg-dull-red focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dull-green focus-visible:ring-offset-2 focus-visible:ring-offset-white" do %>
+    <% if current_list_type_value == "all" && current_sort_mode_value == "off" %>
+      <%= link_to templetes_path, data: { turbo_frame: 'modal_frame' }, class: "group flex-1 h-11 md:h-12 flex items-center justify-center gap-3 rounded-full bg-dull-green text-white font-semibold shadow-lg transition duration-200 ease-out hover:-translate-y-0.5 hover:bg-dull-red focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dull-green focus-visible:ring-offset-2 focus-visible:ring-offset-white" do %>
         <span class="flex size-10 items-center justify-center rounded-full bg-dull-beige/30 text-white transition duration-200 ease-out group-hover:bg-dull-beige/40">
-          <svg class="size-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" /><line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
+          <svg class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"/>
           </svg>
         </span>
-        <span class="text-xs md:text-base tracking-wide">保管場所一覧</span>
+        <span class="text-xs md:text-base tracking-wide">作成・追加</span>
       <% end %>
+    <% end %>
 
-    </div>
-  </nav>
+    <%= link_to locations_path, data: { turbo_frame: 'modal_frame' }, class: "group flex-1 h-11 md:h-12 flex items-center justify-center gap-3 rounded-full bg-dull-green text-white font-semibold shadow-lg transition duration-200 ease-out hover:-translate-y-0.5 hover:bg-dull-red focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dull-green focus-visible:ring-offset-2 focus-visible:ring-offset-white" do %>
+      <span class="flex size-10 items-center justify-center rounded-full bg-dull-beige/30 text-white transition duration-200 ease-out group-hover:bg-dull-beige/40">
+        <svg class="size-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" /><line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
+        </svg>
+      </span>
+      <span class="text-xs md:text-base tracking-wide">保管場所一覧</span>
+    <% end %>
+
+  </div>
 <% end %>

--- a/app/views/stocks/_location.html.erb
+++ b/app/views/stocks/_location.html.erb
@@ -1,11 +1,12 @@
 <div class="bg-white pb-4 mb-10 rounded shadow-sm">
 
   <!-- 保管場所のヘッダー：一覧画面でのみ保管場所名の編集、ストック追加可能 -->
-  <div class="sticky top-38 md:top-42 bg-white border border-box border-white px-4 py-3 mb-1">
+  <div class="sticky z-5 top-38 md:top-42 bg-white border border-box border-white px-4 py-3 mb-1">
     <div class="h-8 flex justify-between items-center">
 
       <%# NOTE: ストック一覧画面 かつ ソートモードがオフのときのみ保管場所名の変更とストックの追加を許可する %>
       <% if (current_list_type_value || list_type) == "all" && (current_sort_mode_value || sort_mode) == "off" %>
+
         <%= link_to edit_location_path(location), data: { turbo_frame: 'modal_frame' }, class: "flex item-center pl-4" do %>
           <h2 class="text-xl md:text-2xl text-f-head font-bold"><%= location.name %></h2>
         <% end %>
@@ -27,15 +28,15 @@
   <%# NOTE: idはbroadcast.prependによるストック追加範囲特定、stocks_listはソートグループ特定用に設置 %>
   <div data-controller="sortable" data-sortable-location-id-value="<%= location.id %>" id="location_<%= location.id %>_stocks_list" class="stocks_list md:grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 md:gap-4 px-4">
     <% if stocks&.find_by(location_id: location.id).present? %>
+
       <% stocks.where(location_id: location.id).each do |stock| %>
         <%= turbo_frame_tag stock, data: { sortable_stock_id_value: stock.id } do %>
           <%= render 'stocks/stock', stock: stock, sort_mode: (current_sort_mode_value || sort_mode) %>
         <% end %>
       <% end %>
+
     <% else %>
-      <%= link_to new_stock_path(location_id: location.id), data: { turbo_frame: 'modal_frame' }, class: "pl-6" do %>
-        <span class="text-lg md:text-xl text-f-body hover:text-dull-green hover:border-b-2 border-dull-green">表示するストックがありません</span>
-      <% end %>
+      <p class="text-lg md:text-xl text-f-head/70 pl-6">表示するストックがありません</p>
     <% end %>
   </div>
 </div>

--- a/app/views/stocks/_stock.html.erb
+++ b/app/views/stocks/_stock.html.erb
@@ -1,4 +1,3 @@
-
 <%# NOTE: ヘルパーにストックカードの描画ロジックを記述 %>
 <div class="relative flex items-center justify-center py-2 rounded border border-box mb-2 lg:mb-0 <%= set_stock_card_design(stock) %>">
   <!-- 左端デザイン帯 -->


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
sticky要素が付与されている位置ずれを修正。

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
ターボやブロードキャスト周りのアクションをreplaceからupdateに変更したことにより、ターゲットとなるタグをパーシャル外へ出した。
その結果、sticky要素が付与されている位置がずれ、レイアウトがくずれていたため修正した。

## 結果
<!-- 対応した結果どうなったのかを記述 -->
これまで通りの挙動に直った。