### PR TITLE
🆙Update: LINEログイン後に自動で転送画面が開くように改善

### DIFF
--- a/app/controllers/line_messages_controller.rb
+++ b/app/controllers/line_messages_controller.rb
@@ -8,14 +8,21 @@ class LineMessagesController < ApplicationController
     @form = LineMessagesForm.new(message: default_message(@shopping_stocks))
   end
 
-  def share
+  def check_form
     @form = LineMessagesForm.new(line_message_params)
 
     if @form.invalid?
       set_shopping_and_notinshopping_stocks(@stocks)
       render :edit, status: :unprocessable_entity
+      return
     end
-    # メッセージ欄が空欄でなければ、ここでLINEでシェアする画面が立ち上がる
+
+    session[:message] = @form.message
+    redirect_to share_line_message_path, status: :see_other
+  end
+
+  def share
+    @message = session[:message] || ""
   end
 
   # NOTE: 以下privateメソッド

--- a/app/javascript/controllers/share_line_messages_controller.js
+++ b/app/javascript/controllers/share_line_messages_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
   static values = {
     liffId: String,
     message: String,
+    redirectUrl: String
   };
 
   async connect() {
@@ -15,12 +16,14 @@ export default class extends Controller {
         withLoginOnExternalBrowser: true
       });
 
-      // ここでliffにログインしてアクセストークンを取得
-      if (!liff.isLoggedIn()) {
-        // withLoginOnExternalBrowser:trueにしているため、未ログイン状態になることはないが、ログを出すようにする
-        console.warn("Not logged in.");
-        alert("LINEへのログインに失敗しました");
-        return;
+      // URLからliffのパラメータを削除して、履歴を置換する
+      history.replaceState({}, "", this.redirectUrlValue);
+
+      const message = this.messageValue;
+
+      // editでmessageを編集していればsessionが空になることはないが、空ならログを出す
+      if (message == "") {
+        console.warn("転送messageは空文字です");
       }
 
       // シェアターゲットピッカーを起動し、送信後に画面を閉じる

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,7 +65,7 @@
       <%= yield %>
     </main>
 
-    <% if user_signed_in? %>
+    <% if user_signed_in? && !(controller_name == "line_messages" && action_name == "share") %>
       <nav id="footer_menu" class="sticky bottom-0 left-0 w-full h-14 bg-white shadow-sm z-10">
         <%= render "shared/footer_menu" %>
       </nav>

--- a/app/views/line_messages/edit.html.erb
+++ b/app/views/line_messages/edit.html.erb
@@ -28,7 +28,8 @@
     </div>
   </details>
 
-  <%= form_with model: @form, url: share_line_message_path, method: :post, data: { action: "turbo:submit-end->modal-frame#close" } do |f| %>
+  <%# NOTE: LIFFのRedirectURLを/line_messages/shareにしたいため、通常の画面遷移にする %>
+  <%= form_with model: @form, url: check_line_message_path, method: :post, data: { turbo: false } do |f| %>
 
     <div class="flex items-center space-x-1 mb-1">
       <svg class="modal-icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">

--- a/app/views/line_messages/share.html.erb
+++ b/app/views/line_messages/share.html.erb
@@ -1,13 +1,15 @@
-<%= render 'shared/modal_wrapper' do %>
-  <h2 class="modal-header">LINEへ転送中</h2>
+<!-- LIFFが初回ログイン時にリダイレクト動作を挟むため、モーダルでなく通常の画面遷移にする -->
+<h2 class="p-4 bg-dull-green text-white text-xl font-bold">LINEへ転送中</h2>
 
-  <!-- 接続後即座にLIFFが起動 -->
-  <div
-    data-controller="share-line-messages"
-    data-share-line-messages-liff-id-value="<%= ENV['LIFF_ID'] %>"
-    data-share-line-messages-message-value="<%= @form.message %>"
-  ></div>
+<!-- 接続後即座にLIFFが起動 -->
+<div
+  data-controller="share-line-messages"
+  data-share-line-messages-liff-id-value="<%= ENV['LIFF_ID'] %>"
+  data-share-line-messages-message-value="<%= @message %>"
+  data-share-line-messages-redirect-url-value="<%= share_line_message_url %>"
+></div>
 
+<div class="mt-8 p-4 bg-white rounded">
   <p class="mb-4">
     LINEアプリ上で送信相手を選択してください。<br>
     転送先は自由に選択できますが、<span class="text-dull-red">誤送信にご注意ください。</span>
@@ -15,8 +17,6 @@
 
   <p class="mb-4">送信後は「閉じる」ボタンでこの画面を閉じてください。</p>
   <div class="w-full mt-8 mb-4 mx-auto text-center cursor-pointer">
-    <span class="px-4 py-2 bg-dull-green text-white rounded shadow-lg" data-action="click->modal-frame#hideModal">
-      閉じる
-    </span>
+    <%= link_to "閉じる", stocks_path, class: "px-4 py-2 bg-dull-green text-white rounded shadow-lg" %>
   </div>
-<% end %>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,7 @@ ja:
       unauthenticated: 認証に失敗しました
     sessions:
       success: ログアウトしました
+      already_signed_out: 既にログアウト済みです
     failure:
       unauthenticated: ログインしてください
   defaults:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,8 @@ Rails.application.routes.draw do
 
   # LINEメッセージ転送
   get "/line_messages/edit", to: "line_messages#edit", as: :edit_line_message
-  post "/line_messages/share", to: "line_messages#share", as: :share_line_message
+  post "/line_messages/check_form", to: "line_messages#check_form", as: :check_line_message
+  get "/line_messages/share", to: "line_messages#share", as: :share_line_message
 
   # PWA関係
   get "/manifest.json", to: "pwa#manifest", defaults: { format: :json }


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
ー 改善前：
LINEへの転送ボタン押下時に、初回のみLINEログインが発生し、ログイン後はストック一覧にリダイレクトされるようになっていた。そして、もう一度転送ボタンを押さないとLINEの転送画面が表示されないようになっていた。
  
🆙 改善後：
初回ボタン押下時のLINEログインは仕様上発生するが、リダイレクト後に転送画面が表示されるようになった。

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
liffの仕様上、liff.loginによりリダイレクトされるエンドポイントURLはGETリクエストでリソースが取得される。
一方で、エンドポイントURLに指定しようとしていた```/line_messages/share```はPOSTだったため、shareアクションが行っていたフォーム情報のバリデーションチェックを別アクションに移譲し、shareはGETリクエストに変更した。
これにより、GETで取得できるshareビューは描画されるとliffの初期化からshareTargetPickerの立ち上げまでを同じ画面で完結できるようになった。