### PR TITLE
🔧chore: ブラウザのポップアップ設定によりLINEが起動しない際のアラートメッセージを具体的な表現に修正

### DIFF
--- a/app/javascript/controllers/share_line_messages_controller.js
+++ b/app/javascript/controllers/share_line_messages_controller.js
@@ -23,7 +23,8 @@ export default class extends Controller {
 
       // editでmessageを編集していればsessionが空になることはないが、空ならログを出す
       if (message == "") {
-        console.warn("転送messageは空文字です");
+        console.warn("LINE share message is null");
+        alert("メッセージが未入力です。\n「LINEで買いもの依頼」画面からメッセージを編集してください。");
       }
 
       // シェアターゲットピッカーを起動し、送信後に画面を閉じる
@@ -34,7 +35,7 @@ export default class extends Controller {
 
     } catch (e) {
       console.error(e);
-      alert("LINEアプリ内で開いているか確認してください");
+      alert("ポップアップブロックがされている場合はLINEが起動しません。\nブラウザの設定からポップアップとリダイレクトを許可してください。");
     }
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
     <!-- LIFF -->
     <script charset="utf-8" src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
 
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", preload: false, "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
ブラウザ設定によりLINE画面が開かないことがあるため、エラーメッセージを具体的な表現に修正した。

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
ポップアップによりブラウザがLINEを別タブで開くのをブロックしてしまう。
（Chromeのデフォルト設定ではポップアップもリダイレクトもユーザーが直接操作したものでないとみなされるとブロックされるみたい）
このため、ブラウザ設定から許可するようにアラートメッセージを表示した。

## 関連するissue
<!-- 実装に紐づくissueがあれば記述 -->
- #170 
