### PR TITLE
🔧chore: モデルから不要なprivateを削除

### DIFF
--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -4,6 +4,7 @@ class History < ApplicationRecord
   validates :status, presence: true
   validates :recording_date, presence: true
 
+  # ユーザー操作によらない値を保存前にセットする
   before_validation :set_status_and_date
   before_validation :nillify_unused_quantity
 

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -13,6 +13,7 @@ class Partnership < ApplicationRecord
   # 新規レコード作成時に有効期限（30分）を設定する
   before_create :set_expires_at
 
+  # ペアレコードの双方向作成、更新、削除に関するロジック
   def pair
     self.class
       .where(user_id: partner_id, partner_id: user_id)
@@ -35,17 +36,17 @@ class Partnership < ApplicationRecord
     end
   end
 
-  # NOTE: 以下private
-  private
-
-  def set_expires_at
-    self.expires_at ||= 30.minutes.from_now
-  end
-
   def self.create_request_pair!(user, partner_user)
     transaction do
       applicant = user.partnerships.create!(partner_id: partner_user.id, status: :sended)
       partner_user.partnerships.create!(partner_id: user.id, status: :pending, expires_at: applicant.expires_at)
     end
+  end
+
+  # NOTE: 以下private
+  private
+
+  def set_expires_at
+    self.expires_at ||= 30.minutes.from_now
   end
 end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -30,9 +30,6 @@ class Stock < ApplicationRecord
     end
   end
 
-  # NOTE: 以下privateメソッド
-  private
-
   # ransackのv4系から必要になった検索を許可するカラムの指定
   def self.ransackable_attributes(auth_object = nil)
     [ "name" ]

--- a/app/models/templete.rb
+++ b/app/models/templete.rb
@@ -6,8 +6,6 @@ class Templete < ApplicationRecord
 
   scope :with_location_name, ->(location_name) { where(location_name: location_name) }
 
-  private
-
   # indexアクションで保管場所名の配列を作成するために使用
   def self.prefixed_location_names_array
     group(:location_name)


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
モデルに不要なprivateがあったため文言を削除

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
クラスメソッドはprivate内に定義してもpublicになるため、意味がないことが分かった。
このため、不要な宣言を削除する。